### PR TITLE
Fixes #106 Ruchy cannot find by waypoint

### DIFF
--- a/website/lib/Waypointy.class.php
+++ b/website/lib/Waypointy.class.php
@@ -6,18 +6,28 @@ class Waypointy {
     // report current activity to stdout
     private $verbose;
 
+    private $prefiksy_oc = array('OC', 'OP', 'OK', 'GE', 'OZ', 'OU', 'ON', 'OL', 'OJ', 'OS', 'GD', 'GA', 'VI', 'MS', 'TR', 'EX', 'GR', 'RH', 'OX', 'OB', 'OR'); // oc i inne full wypas
+    private $prefiksy_inne = array('GC');     // cache from Geocaching
+    private $prefiksy_inne_1 = array('N');    // cache from Navicache (N....)
+    private $prefiksy_inne_3 = array('WPG');
+
     // base query
-    const SELECT_WAYPOINT = <<<EOQUERY
+    const SELECT_WAYPOINTY = <<<EOQUERY
 SELECT wp.`waypoint`, wp.`lat`, wp.`lon`, wp.`name`, wp.`owner`, wp.`typ`, wpt.`cache_type`, wp.`link`, wp.`kraj`, wpc.`country`
  FROM `gk-waypointy` wp
  LEFT OUTER JOIN `gk-waypointy-country` wpc ON wp.`kraj` = wpc.`kraj`
  LEFT OUTER JOIN `gk-waypointy-type` wpt ON wp.`typ` = wpt.`typ`
 EOQUERY;
 
+    const SELECT_RUCHY = <<<EOQUERY
+SELECT `lat` , `lon` , `country`, `alt` FROM `gk-ruchy`
+EOQUERY;
+
     //~ waypoint attributes
     public $waypoint;
     public $lat;
     public $lon;
+    public $alt;
     public $name;
     public $owner;
     public $typ;
@@ -25,6 +35,7 @@ EOQUERY;
     public $cache_link;
     public $kraj;
     public $country;
+    public $country_code;
 
     public function __construct($dblink, $verbose) {
         $this->dblink = $dblink;
@@ -32,11 +43,68 @@ EOQUERY;
     }
 
     public function getByWaypoint($waypoint) {
-        $action = 'Waypointy::getByWaypoint';
         if (!isset($waypoint) || $waypoint == '') {
             throw new Exception($action.' waypoint expected');
         }
-        if (!($stmt = $this->dblink->prepare(self::SELECT_WAYPOINT
+        if ($this->isImportedWaypoint($waypoint)) {
+            return $this->getByWaypointFromWaypointy($waypoint);
+        }
+
+        return $this->getByWaypointFromRuchy($waypoint);
+    }
+
+    public function isOCWaypoint($waypoint) {
+        return in_array(substr(strtoupper($waypoint), 0, 2), $this->prefiksy_oc);
+    }
+
+    public function isGCWaypoint($waypoint) {
+        return in_array(substr(strtoupper($waypoint), 0, 2), $this->prefiksy_inne);
+    }
+
+    public function isWPGWaypoint($waypoint) {
+        return in_array(substr(strtoupper($waypoint), 0, 3), $this->prefiksy_inne_3);
+    }
+
+    public function isNavicache($waypoint) {
+        return in_array(substr(strtoupper($waypoint), 0, 1), $this->prefiksy_inne_1);
+    }
+
+    public function isImportedWaypoint($waypoint) {
+        return $this->isOCWaypoint($waypoint) or $this->isWPGWaypoint($waypoint);
+    }
+
+    public function getByWaypointFromRuchy($waypoint) {
+        $action = 'Waypointy::getByWaypointFromRuchy';
+
+        if (!($stmt = $this->dblink->prepare(self::SELECT_RUCHY
+                       .' WHERE `waypoint` LIKE ? ORDER BY `data_dodania` DESC LIMIT 1'))) {
+            throw new Exception($action.' prepare failed: ('.$this->dblink->errno.') '.$this->dblink->error);
+        }
+        if (!$stmt->bind_param('s', $waypoint)) {
+            throw new Exception($action.' binding parameters failed: ('.$stmt->errno.') '.$stmt->error);
+        }
+        if (!$stmt->execute()) {
+            throw new Exception($action.' execute failed: ('.$stmt->errno.') '.$stmt->error);
+        }
+        $this->waypoint = $waypoint;
+        if ($this->isGCWaypoint($waypoint)) {
+            $this->cache_link = "http://www.geocaching.com/seek/cache_details.aspx?wp=$waypoint";
+        } elseif ($this->isNavicache($waypoint)) {
+            $this->cache_link = 'http://www.navicache.com/cgi-bin/db/displaycache2.pl?CacheID='.hexdec(substr($waypoint, 1, 10));
+        }
+
+        if (!$stmt->bind_result($this->lat, $this->lon, $this->country_code, $this->alt)) {
+            throw new Exception($action.' binding output parameters failed: ('.$stmt->errno.') '.$stmt->error);
+        }
+        $stmtFetch = $stmt->fetch();
+        $stmt->close();
+
+        return $stmtFetch;
+    }
+
+    public function getByWaypointFromWaypointy($waypoint) {
+        $action = 'Waypointy::getByWaypointFromWaypointy';
+        if (!($stmt = $this->dblink->prepare(self::SELECT_WAYPOINTY
                        .' WHERE wp.`waypoint` LIKE ?'
                        .' LIMIT 1'))) {
             throw new Exception($action.' prepare failed: ('.$this->dblink->errno.') '.$this->dblink->error);
@@ -61,7 +129,7 @@ EOQUERY;
         if (!isset($waypointName) || $waypointName == '') {
             throw new Exception($action.' waypoint name expected');
         }
-        if (!($stmt = $this->dblink->prepare(self::SELECT_WAYPOINT
+        if (!($stmt = $this->dblink->prepare(self::SELECT_WAYPOINTY
                        .' WHERE wp.`name` LIKE CONCAT(\'%\',?,\'%\')'
                        .' LIMIT 1'))) {
             throw new Exception($action.' prepare failed: ('.$this->dblink->errno.') '.$this->dblink->error);

--- a/website/ruchy.php
+++ b/website/ruchy.php
@@ -462,19 +462,20 @@ if ($kret_formname == 'ruchy') { //  **************************************** OP
             exit;
         }
         // -- Piwik Tracking API init --
-        require_once 'templates/piwik-php-tracker/PiwikTracker.php';
-        PiwikTracker::$URL = PIWIK_URL;
-        $piwikTracker = new PiwikTracker($idSite = PIWIK_SITE_ID);
-        // $piwikTracker->enableBulkTracking();
-        $piwikTracker->setTokenAuth(PIWIK_TOKEN);
-        $piwikTracker->setUrl($config['adres'].'ruchy.php');
-        $piwikTracker->setIp($_SERVER['HTTP_X_FORWARDED_FOR']);
-        $piwikTracker->setUserAgent("$kret_app $kret_app_ver");
-        $piwikTracker->setBrowserLanguage($kret_mobile_lang);
-        $piwikTracker->doTrackPageView('GKMoved');
-        // $piwikTracker->doBulkTrack();
+        if (PIWIK_URL !== '') {
+            require_once 'templates/piwik-php-tracker/PiwikTracker.php';
+            PiwikTracker::$URL = PIWIK_URL;
+            $piwikTracker = new PiwikTracker($idSite = PIWIK_SITE_ID);
+            // $piwikTracker->enableBulkTracking();
+            $piwikTracker->setTokenAuth(PIWIK_TOKEN);
+            $piwikTracker->setUrl($config['adres'].'ruchy.php');
+            $piwikTracker->setIp($_SERVER['HTTP_X_FORWARDED_FOR']);
+            $piwikTracker->setUserAgent("$kret_app $kret_app_ver");
+            $piwikTracker->setBrowserLanguage($kret_mobile_lang);
+            $piwikTracker->doTrackPageView('GKMoved');
+            // $piwikTracker->doBulkTrack();
+        }
         // -- Piwik Tracking API end --
-
         //$TRESC = "Ok! <a href=\"konkret.php?id=$kretid\">" . _("Go to GeoKret page") . "</a>";
 
         include_once 'aktualizuj.php';

--- a/website/szukaj-ajax.php
+++ b/website/szukaj-ajax.php
@@ -122,6 +122,8 @@ if ($_REQUEST['skad'] == 'ajax') {
         }
     } elseif (!empty($_REQUEST['wpt'])) { // ****************************************  waypoint
         try {
+            $return['lat'] = '';
+            $return['lon'] = '';
             $wpt = mysqli_real_escape_string($link, $_REQUEST['wpt']);
             include_once 'lib/Waypointy.class.php';
             $waypointy = new Waypointy($link, false);
@@ -133,7 +135,7 @@ if ($_REQUEST['skad'] == 'ajax') {
                 $lat = $waypointy->lat;
                 $lon = $waypointy->lon;
 
-                if (!empty($lat) and !empty($lon)) {
+                if (!empty(trim($lat)) and !empty(trim($lon))) {
                     $country = $waypointy->country;
                     $countryCode = '';
                     $return['tresc'] = cacheOk($waypointy->cache_link, $waypointy->name, $waypointy->owner, $waypointy->cache_type, $waypointy->country, $countryCode);
@@ -142,8 +144,6 @@ if ($_REQUEST['skad'] == 'ajax') {
                     echo json_encode($return);
                 } else {
                     $return['tresc'] = cacheWithoutLatLon($waypointy->name, $waypointy->cache_link);
-                    $return['lat'] = '';
-                    $return['lon'] = '';
                     echo json_encode($return);
                 }
             }
@@ -160,6 +160,8 @@ if ($_REQUEST['skad'] == 'ajax') {
         include_once 'lib/Waypointy.class.php';
         $waypointy = new Waypointy($link, false);
         try {
+            $return['lat'] = '';
+            $return['lon'] = '';
             $byNameCount = $waypointy->countDistinctName($_REQUEST['NazwaSkrzynki']);
             $return['IleSkrzynek'] = $byNameCount;
 
@@ -187,10 +189,13 @@ if ($_REQUEST['skad'] == 'ajax') {
                 $hasResult = $waypointy->getByName($_REQUEST['NazwaSkrzynki']);
                 if (!$hasResult) {// never the case
                     $return['tresc'] = cacheNotFound();
-                } else {
+                } elseif (!empty(trim($waypointy->lat)) and !empty(trim($waypointy->lon))) {
                     $return['tresc'] = cacheOk($waypointy->cache_link, $waypointy->name, $waypointy->owner, $waypointy->cache_type, $waypointy->country, $countryCode);
                     $return['lat'] = $waypointy->lat;
                     $return['lon'] = $waypointy->lon;
+                    $return['wpt'] = $waypointy->waypoint;
+                } else {
+                    $return['tresc'] = cacheWithoutLatLon($waypointy->waypoint, $waypointy->name, $waypointy->cache_link);
                     $return['wpt'] = $waypointy->waypoint;
                 }
             } // jeśli jest jedna skrzynka

--- a/website/szukaj-ajax.php
+++ b/website/szukaj-ajax.php
@@ -8,24 +8,35 @@ require_once '__sentry.php';
 require_once 'wybierz_jezyk.php'; // choose the user's language
 require 'templates/konfig.php';    // config
 
+function waypointLinkLabel($waypoint, $name) {
+    if (trim($name) !== '') {
+        return trim($name);
+    }
+
+    return sprintf(_('waypoint %s'), strtoupper($waypoint));
+}
+
 /**
  * json result (tresc) to send when ONE cache is selected.
  */
-function cacheOk($cache_link, $name, $owner, $cache_type, $cache_country, $countryCode) {
+function cacheOk($waypoint, $cache_link, $name, $owner, $cache_type, $cache_country, $countryCode) {
     $flagPlaceholder = '';
     if (trim($countryCode) !== '') {
-        $flagPlaceholder = '<img src="'.CONFIG_CDN_IMAGES.'/country-codes/'.$countryCode.'.png" width="16" height="11" alt="'._('flag').'"/>';
+        $flagPlaceholder = '<img src="'.CONFIG_CDN_IMAGES.'/country-codes/'.$countryCode.'.png" width="16" height="11"'
+                         .' alt="'._('flag').'" title="'.$countryCode.'"/>';
     }
     if (trim($owner) !== '') {
         $ownerPlaceholder = '('.sprintf(_('by %s'), $owner).')';
     }
 
-    $result = '<img src="'.CONFIG_CDN_IMAGES.'/icons/ok.png" alt="'._('OK').'" width="16" height="16" /> <a href="'.$cache_link.'" target="_opencaching">'.$name.' <i class="glyphicon glyphicon-link"></i></a> '.$ownerPlaceholder.'<br />';
+    $result = '<img src="'.CONFIG_CDN_IMAGES.'/icons/ok.png" alt="'._('OK').'" width="16" height="16" /> <a href="'.$cache_link.'" target="_opencaching">'.waypointLinkLabel($waypoint, $name).' <i class="glyphicon glyphicon-link"></i></a> '.$ownerPlaceholder.'<br />';
     if (trim($cache_type) !== '') {
         $result .= sprintf(_('cache type: %s'), _($cache_type)).'<br/>';
     }
     if (trim($cache_country) !== '') {
         $result .= sprintf(_('country: %s %s'), $flagPlaceholder, _($cache_country));
+    } elseif (trim($countryCode) !== '') {
+        $result .= sprintf(_('country: %s'), $flagPlaceholder);
     }
 
     return $result;
@@ -41,8 +52,8 @@ function cacheNotFound() {
 /**
  * json result (tresc) to send when selected cache is not associated with lat/lon.
  */
-function cacheWithoutLatLon($name, $cache_link) {
-    $link_wpt = '<a href="'.$cache_link.'" target="_opencaching">'.$name.' <i class="glyphicon glyphicon-link"></i></a>';
+function cacheWithoutLatLon($waypoint, $name, $cache_link) {
+    $link_wpt = '<a href="'.$cache_link.'" target="_opencaching">'.waypointLinkLabel($waypoint, $name).' <i class="glyphicon glyphicon-link"></i></a>';
 
     return '<img src="'.CONFIG_CDN_IMAGES.'/icons/info3.png" alt="info" width="16" height="16" /> '.sprintf(_('Please provide the coordinates (lat/lon) of the cache %s in the "coordinates" input box.'), $link_wpt).'<br />'.
         sprintf(_('<a href="%s">Learn more about hiding geokrets in GC caches</a>'), $config['adres'].'help.php#locationdlagc');
@@ -136,14 +147,13 @@ if ($_REQUEST['skad'] == 'ajax') {
                 $lon = $waypointy->lon;
 
                 if (!empty(trim($lat)) and !empty(trim($lon))) {
-                    $country = $waypointy->country;
-                    $countryCode = '';
-                    $return['tresc'] = cacheOk($waypointy->cache_link, $waypointy->name, $waypointy->owner, $waypointy->cache_type, $waypointy->country, $countryCode);
+                    $return['tresc'] = cacheOk($waypointy->waypoint, $waypointy->cache_link, $waypointy->name,
+                      $waypointy->owner, $waypointy->cache_type, $waypointy->country, $waypointy->country_code);
                     $return['lat'] = $lat;
                     $return['lon'] = $lon;
                     echo json_encode($return);
                 } else {
-                    $return['tresc'] = cacheWithoutLatLon($waypointy->name, $waypointy->cache_link);
+                    $return['tresc'] = cacheWithoutLatLon($waypointy->waypoint, $waypointy->name, $waypointy->cache_link);
                     echo json_encode($return);
                 }
             }
@@ -190,7 +200,8 @@ if ($_REQUEST['skad'] == 'ajax') {
                 if (!$hasResult) {// never the case
                     $return['tresc'] = cacheNotFound();
                 } elseif (!empty(trim($waypointy->lat)) and !empty(trim($waypointy->lon))) {
-                    $return['tresc'] = cacheOk($waypointy->cache_link, $waypointy->name, $waypointy->owner, $waypointy->cache_type, $waypointy->country, $countryCode);
+                    $return['tresc'] = cacheOk($waypointy->waypoint, $waypointy->cache_link, $waypointy->name,
+                      $waypointy->owner, $waypointy->cache_type, $waypointy->country, $waypointy->country_code);
                     $return['lat'] = $waypointy->lat;
                     $return['lon'] = $waypointy->lon;
                     $return['wpt'] = $waypointy->waypoint;


### PR DESCRIPTION
fix default lat/lon to empty
fix cache without lat/lon when only one result
re add legacy waypoint search via gk-ruchy table
fix link label when no cache name
add flag image on ruchy based result
display waypoint uppercase
handle case where piwik is disabled
improve exception handler

Co-authored-by: Mathieu Alorent <github@kumy.net>