### PR TITLE
Fixes #193 chain QA test within travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,25 @@ script:
 jobs:
   include:
     - stage: deploy
+      if: branch IN (master, boly38)
       php: 5.6
       script:
         - scripts/export-translations-github.sh
         - scripts/compile-translations.sh
+    - stage: qaTests
+      if: branch IN (master, boly38)
+      script:
+        # TRAVIS_QA_TOKEN from https://travis-ci.org/geokrety/geokrety-website/settings
+        # TRAVIS_BRANCH   from https://docs.travis-ci.com/user/environment-variables/
+        - bash ./.travis_hook_qa.sh ${TRAVIS_QA_TOKEN} ${TRAVIS_BRANCH}
+notifications:
+    # doc: https://docs.travis-ci.com/user/notifications/#configuring-irc-notifications
+    irc:
+        channels:
+        - "chat.freenode.net#geokrety"
+        on_success: change # default: always
+        on_failure: always # default: always
+        template:
+        - "%{repository_slug}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}"
+        - "Change view : %{compare_url}"
+        - "Build details : %{build_url}"

--- a/.travis_hook_qa.sh
+++ b/.travis_hook_qa.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# shell script that ask to travis to build QA tests for a given branch
+#
+# QA_TOKEN  as arg1 : travis token to trigger qa build
+# QA_BRANCH (optional) as arg2 : branch to test (default: master) - allowed branches are: master or boly38
+#
+# shell arg
+QA_TOKEN=$1
+QA_BRANCH=$2
+QA_BRANCH=${QA_BRANCH:-master}
+QA_SLUG=geokrety%2Fgeokrety-website-qa
+QA_SLOG=geokrety/geokrety-website-qa
+
+if [ "${QA_TOKEN}" == "" ]; then
+  echo " X need QA_TOKEN as arg 1";
+  exit 1;
+fi
+
+body='{
+ "request": {
+ "message": "this is an api request",
+ "config": {
+   "env": {
+     "TARGET_ENV": "'${QA_BRANCH}'"
+   }
+  }
+}}'
+echo " * requesting ${QA_SLOG} build with following parameters: ${body}";
+
+REQUEST_RESULT=$(curl -s -X POST \
+   -H "Content-Type: application/json" \
+   -H "Accept: application/json" \
+   -H "Travis-API-Version: 3" \
+   -H "Authorization: token ${QA_TOKEN}" \
+   -d "$body" \
+   https://api.travis-ci.org/repo/${QA_SLUG}/requests)
+
+echo " * request result:"
+echo "${REQUEST_RESULT}"
+
+if [[ ${REQUEST_RESULT} == *"access denied"* ]]; then
+  echo " X request denied"
+  exit 1
+fi
+
+echo " * now waiting pending QA tests build"
+. ./.travis_wait_build.sh ${QA_TOKEN}

--- a/.travis_wait_build.sh
+++ b/.travis_wait_build.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# shell script that wait travis build result and report build state string
+#
+# QA_TOKEN  as arg1 : travis token to trigger qa build
+#
+# DEV NOTE:
+# - build takes between 3 and 4 minutes (but start could be delayed..)
+# - possible state: created|started|passed|failed
+# shell arg
+QA_TOKEN=$1
+QA_SLUG=geokrety%2Fgeokrety-website-qa
+QA_SLOG=geokrety/geokrety-website-qa
+QA_BRANCH=master
+
+if [ "${QA_TOKEN}" == "" ]; then
+  echo " X need QA_TOKEN as arg 1";
+  exit 1;
+fi
+
+ITERATION_RETRY_SLEEP=10
+ITERATION_MAX=42
+# 420 sec == 7 min max wait
+BUILD_STATE=""
+ITERATION=0
+
+function getBuildInfo() {
+    echo " * `date '+%Y-%m-%d %H:%M:%S'` [${ITERATION}] requesting ${QA_SLOG} builds";
+    BUILD_INFO=$(curl -s -X GET \
+       -H "Content-Type: application/json" \
+       -H "Accept: application/json" \
+       -H "Travis-API-Version: 3" \
+       -H "Authorization: token ${QA_TOKEN}" \
+       https://api.travis-ci.org/repo/${QA_SLUG}/builds?branch.name=${QA_BRANCH}\&sort_by=started_atdesc\&limit=1 )
+
+    if [[ ${BUILD_INFO} == *"access denied"* ]]; then
+      echo " X access denied"
+      exit 1
+    fi
+    if [[ ${BUILD_INFO} == *"not_found"* ]]; then
+      echo " X not found"
+      exit 1
+    fi
+
+    BUILD_STATE=$(echo "${BUILD_INFO}" | grep -Po '"state":.*?[^\\]",'|head -n1| awk -F "\"" '{print $4}')
+    BUILD_ID=$(echo "${BUILD_INFO}" | grep '"id": '|head -n1| awk -F'[ ,]' '{print $8}')
+}
+
+# ToCheck over the time : possible improvement using build_id to ignore instead of waiting intermediate state
+# wait 'created ' or 'started' state
+while [[ ( "${BUILD_STATE}" != "created" ) && ( "${BUILD_STATE}" != "started" ) && ( ${ITERATION} -lt ${ITERATION_MAX} ) ]]
+do
+    if [ ${ITERATION} -ne 0 ]; then
+      sleep ${ITERATION_RETRY_SLEEP}
+    fi
+    DATETIME=$(date '+%Y-%m-%d %H:%M:%S')
+    getBuildInfo
+    echo " * ${DATETIME} https://travis-ci.org/${QA_SLOG}/builds/${BUILD_ID} => ${BUILD_STATE}"
+    if [[ ( "${BUILD_STATE}" != "created" ) && ( "${BUILD_STATE}" != "started" ) ]]; then
+      ITERATION=$((ITERATION + 1))
+    fi
+done
+
+# wait 'passed' or 'failed' final state
+while [[ ( "${BUILD_STATE}" != "passed" ) && ( "${BUILD_STATE}" != "failed" ) && ( ${ITERATION} -lt ${ITERATION_MAX} ) ]]
+do
+    if [ ${ITERATION} -ne 0 ]; then
+      sleep ${ITERATION_RETRY_SLEEP}
+    fi
+    DATETIME=$(date '+%Y-%m-%d %H:%M:%S')
+    getBuildInfo
+    echo " * ${DATETIME} https://travis-ci.org/${QA_SLOG}/builds/${BUILD_ID} => ${BUILD_STATE}"
+    if [[ ( "${BUILD_STATE}" != "passed" ) && ( "${BUILD_STATE}" != "failed" ) ]]; then
+      ITERATION=$((ITERATION + 1))
+    fi
+done
+
+# do we reach timeout ?
+if [ ${ITERATION} -ge ${ITERATION_MAX} ]; then
+  DATETIME=$(date '+%Y-%m-%d %H:%M:%S')
+  echo " * ${DATETIME} build #${QA_BUILD_ID} Timeout, state was \"${BUILD_STATE}\" after $((ITERATION * ITERATION_RETRY_SLEEP)) seconds"
+  exit 1
+fi
+
+if [ "${BUILD_STATE}" == "failed" ]; then
+  exit 1
+fi


### PR DESCRIPTION
Related to #193 chain QA test within travis build

-- setup TRAVIS_QA_TOKEN (on travis side)
- add wait testQA external build 5 minutes
- add notification on irc

---
Please note that the current branch (feature/webhookQA) is not matching qaTest stage conditions. That's why this tests has been done previously. cf #193 

for review purpose, if you were seeing day after day git diff, you could rely on temp branch : `temp_for_review_before_squash_rebase_webhook_qa_v0`

---
please note that this PR could help travis users following [this post](https://stackoverflow.com/questions/32118067/triggering-builds-of-dependent-projects-in-travis-ci)