### PR TITLE
Fixes #133 unknown waypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ docker-compose.dev.yml
 git-version
 .php_cs.cache
 .project
+*.iml
 vars/
 # please use 'composer install' to generate vendor/
 vendor/

--- a/website/szukaj-ajax.php
+++ b/website/szukaj-ajax.php
@@ -43,10 +43,16 @@ function cacheOk($waypoint, $cache_link, $name, $owner, $cache_type, $cache_coun
 }
 
 /**
- * json result (tresc) to send when NO cache is found.
+ * json result (tresc) to send when NO cache found.
  */
-function cacheNotFound() {
+function noCacheFound() {
     return '<img src="'.CONFIG_CDN_IMAGES.'/icons/error.png" alt="error" width="16" height="16" /> '._('No cache found');
+}
+/**
+ * json result (tresc) to send when cache code is unknown.
+ */
+function cacheUnknown() {
+    return '<img src="'.CONFIG_CDN_IMAGES.'/icons/error.png" alt="error" width="16" height="16" /> '._('Missing or invalid coordinates');
 }
 
 /**
@@ -140,7 +146,7 @@ if ($_REQUEST['skad'] == 'ajax') {
             $waypointy = new Waypointy($link, false);
             $hasResult = $waypointy->getByWaypoint($wpt);
             if (!$hasResult) {
-                $return['tresc'] = cacheNotFound();
+                $return['tresc'] = cacheUnknown();
                 echo json_encode($return);
             } else {
                 $lat = $waypointy->lat;
@@ -176,7 +182,7 @@ if ($_REQUEST['skad'] == 'ajax') {
             $return['IleSkrzynek'] = $byNameCount;
 
             if ($byNameCount == 0) {// no result
-                $return['tresc'] = cacheNotFound();
+                $return['tresc'] = noCacheFound();
             } elseif ($byNameCount > 1) {
                 $maxCache = 4;
                 if ($byNameCount < $maxCache) {
@@ -198,7 +204,7 @@ if ($_REQUEST['skad'] == 'ajax') {
             } else { // == 1
                 $hasResult = $waypointy->getByName($_REQUEST['NazwaSkrzynki']);
                 if (!$hasResult) {// never the case
-                    $return['tresc'] = cacheNotFound();
+                    $return['tresc'] = cacheUnknown();
                 } elseif (!empty(trim($waypointy->lat)) and !empty(trim($waypointy->lon))) {
                     $return['tresc'] = cacheOk($waypointy->waypoint, $waypointy->cache_link, $waypointy->name,
                       $waypointy->owner, $waypointy->cache_type, $waypointy->country, $waypointy->country_code);


### PR DESCRIPTION
relate to #133 

- update message when waypoint code search is unknown

'boly38' branch is updated with the commit

PR build - about qa tests :
- qa test update is not on master on qa side 
- qa tests are done on 'master' env (rec) which doesn't reflect PR codebase
- dedicated qa branch [Branch feature/ruchyUnknownMsg](https://github.com/geokrety/geokrety-website-qa/tree/feature/ruchyUnknownMsg) were used with [build 107](https://travis-ci.org/geokrety/geokrety-website-qa/builds/445828400) to validate expected message (TARGET_ENV=[boly38](https://boly38.gk.kumy.org/))