### PR TITLE
Fix #243: include_once inside function is bad idea

### DIFF
--- a/website/aktualizuj.php
+++ b/website/aktualizuj.php
@@ -93,7 +93,6 @@ function aktualizuj_obrazek_statystyki($userid) {
 function zlicz_droge($ruch_id) {
     // calculate distance between this and previous location
 
-    include_once 'templates/konfig.php';
     $link = DBConnect();
 
     $result = mysqli_query($link, "SELECT `id`, `data` FROM `gk-ruchy` WHERE `ruch_id`='$ruch_id' LIMIT 1");
@@ -144,7 +143,6 @@ function aktualizuj_droge($id) {
     //$sql7 = "UPDATE `gk-geokrety` SET `droga` = '$droga_total' WHERE `id` = '$id' LIMIT 1";
     //$result7 = mysql_query($sql7);
 
-    include_once 'templates/konfig.php';
     $link = DBConnect();
 
     $sql = "
@@ -174,7 +172,6 @@ AND ru1.droga <> round( 6371 * acos( cos( radians(ru1.lat) ) * cos( radians( ru2
 // counts number of visited caches
 // (counts distinct values of lat+lon for logstype 0 and 3 only
 function aktualizuj_skrzynki($id) {
-    include_once 'templates/konfig.php';
     $link = DBConnect();
 
     $sql7 = "UPDATE `gk-geokrety` gk SET skrzynki =
@@ -185,7 +182,6 @@ function aktualizuj_skrzynki($id) {
 
 // counts number of photos
 function aktualizuj_zdjecia($id) {
-    include_once 'templates/konfig.php';
     $link = DBConnect();
 
     $sql7 = "UPDATE `gk-geokrety` gk SET zdjecia =
@@ -197,7 +193,6 @@ function aktualizuj_zdjecia($id) {
 // updates the ost_pozycja_id which is the ruch_id for last log of type grabbed, dropped, met or archived
 // all these log types change or may change the current location (and state) of geokret
 function aktualizuj_ost_pozycja_id($id) {
-    include_once 'templates/konfig.php';
     $link = DBConnect();
 
     $result = mysqli_query($link,
@@ -229,7 +224,6 @@ function aktualizuj_ost_pozycja_id($id) {
 
 // updates the ost_log_id which is the ruch_id for last log
 function aktualizuj_ost_log_id($id) {
-    include_once 'templates/konfig.php';
     $link = DBConnect();
 
     $result = mysqli_query($link,
@@ -297,7 +291,6 @@ function aktualizuj_rekach($gkid) {
         return;
     }
 
-    include_once 'templates/konfig.php';
     $link = DBConnect();
 
     $handsof = 'NULL';
@@ -318,7 +311,6 @@ function aktualizuj_rekach($gkid) {
 // --------------------------------------- RACES --------------------------------//
 
 function aktualizuj_race($gk_id, $lat1, $lon1) {
-    include_once 'templates/konfig.php';
     $link = DBConnect();
 
     $sql = "SELECT rg.raceGkId, r.raceid, r.raceOpts, r.targetlat, r.targetlon, rg.finished, r.raceend, r.targetDist, r.targetCaches, rg.initDist, rg.initCaches, gk.skrzynki, gk.droga

--- a/website/api-login2secid.php
+++ b/website/api-login2secid.php
@@ -6,12 +6,11 @@ $kret_haslo1 = $_POST['password'];
 $kret_login = $_POST['login'];
 
 if (!empty($kret_login) and !empty($kret_haslo1)) { // logging in with supplied data
-    include_once 'templates/konfig.php';
     include 'czysc.php';
     include_once 'fn_haslo.php';
 
     function haszuj($str) {
-        include_once 'templates/konfig.php';
+        global $config;
         $md5_string1 = $config['md5_string1'];
         $md5_string2 = $config['md5_string2'];
 

--- a/website/api-secid-change.php
+++ b/website/api-secid-change.php
@@ -12,7 +12,6 @@ if ($_GET['confirmed'] == '1') {
     include_once 'fn-generate_secid.php';
     $secid = generateRandomString(128);
 
-    include_once 'templates/konfig.php';
     $link = DBConnect();
 
     $result = mysqli_query($link, "UPDATE `gk-users` SET `secid` = '$secid' WHERE `gk-users`.`userid` = $userid;");

--- a/website/czy_obserwowany.php
+++ b/website/czy_obserwowany.php
@@ -3,8 +3,6 @@
 // sprawdza obserwacje geokreta ݦⳳߟ śćńółź
 // $userid=$longin_status['userid'];
 function czy_obserwowany($id, $userid) {
-    include_once 'templates/konfig.php';
-
     //if(!function_exists(longin_chceck)) include("longin_chceck.php");
     //$longin_status = longin_chceck();
     //$userid=$longin_status['userid'];

--- a/website/czysc.php
+++ b/website/czysc.php
@@ -36,7 +36,6 @@ function longlinewrap($str, $maxLength = 45, $char = ' ') {
 }
 
 function czysc($string) {
-    include_once 'templates/konfig.php';
     $link = DBConnect();
 
     //return  (trim(mysqli_escape_string($link, htmlentities(strip_tags(stripslashes($newStr)), ENT_QUOTES, 'UTF-8'))));
@@ -67,7 +66,6 @@ function czysc($string) {
 // }
 
 function parse_bbcode($string) {
-    include_once 'templates/konfig.php';
     $link = DBConnect();
 
     $string = htmlentities(iconv('UTF-8', 'UTF-8//IGNORE', $string), ENT_NOQUOTES, 'UTF-8');

--- a/website/email_errors.php
+++ b/website/email_errors.php
@@ -10,7 +10,6 @@ function email_errors($from_date, $from_sev = 7) {
         }
     }
 
-    include_once 'templates/konfig.php';
     include_once 'db.php';
 
     $db = new db();

--- a/website/fn_haslo.php
+++ b/website/fn_haslo.php
@@ -26,9 +26,7 @@
 
 if (!function_exists(haslo_koduj)) {
     include 'templates/PasswordHash.php';
-    if (!isset($config)) {
-        include_once 'templates/konfig.php';
-    }
+    global $config;
 
     // tworzy hasz hasła
 

--- a/website/konkret-mapka.php
+++ b/website/konkret-mapka.php
@@ -22,8 +22,7 @@ function konkret_mapka($id) {
         $db = new db();
     }
     // ------------------------------------------------------------
-
-    include_once 'templates/konfig.php';
+    global $config;
     include_once 'waypoint_info.php';
 
     $result = $db->exec(

--- a/website/lost_mapka.php
+++ b/website/lost_mapka.php
@@ -5,7 +5,7 @@ require_once '__sentry.php';
 // this page shows details of a geokret śćńółźłśśóś
 $smarty_cache_this_page = 0; // this page should be cached for n seconds
 require_once 'smarty_start.php';
-include_once 'templates/konfig.php';
+global $config, $GOOGLE_MAP_KEY, $GOOGLE_MAP_KEY;
 
 $TYTUL = _('Geokrets on the map').' :: β (beta)';
 
@@ -40,7 +40,6 @@ if ($lat == 0 and $lon == 0) {
 
 $HEAD .= '<script>var center_lat='.$lat.'; var center_lon='.$lon.';</script>';
 
-include_once 'templates/konfig.php';
 $OGON .= '<script src="http://maps.google.com/maps?file=api&amp;v=2.x&amp;key='.$GOOGLE_MAP_KEY.'" type="text/javascript"></script>
 <script type="text/javascript" src="mapka_kretow.js"></script>';
 $BODY = 'onload="load()" onunload="GUnload()"';

--- a/website/mapka_kretow.php
+++ b/website/mapka_kretow.php
@@ -5,6 +5,7 @@ require_once '__sentry.php';
 // smarty cache
 $smarty_cache_this_page = 0; // this page should be cached for n seconds
 require_once 'smarty_start.php';
+global $GOOGLE_MAP_KEY;
 
 $TYTUL = _('Geokrets on the map').' :: β (beta)';
 
@@ -27,7 +28,6 @@ if (!isset($g_userid)) {  // jeśli nie ma parametru userid
 
 if (isset($g_userid)) {
     // wyciągnięcie lat/lon usera
-    include_once 'templates/konfig.php';
     $sql = "SELECT `lat`, `lon` FROM `gk-users` WHERE `userid`='$g_userid' LIMIT 1";
     $result = mysqli_query($link, $sql);
     $row = mysqli_fetch_array($result);

--- a/website/obrazek.php
+++ b/website/obrazek.php
@@ -2,7 +2,7 @@
 
 function obrazek($alfabet = 'a c d e f h i k m n p s t w x y z 1 2 3 4 5 7 8') {
     // generates antispam token + picture śćńółż
-    include_once 'templates/konfig.php';
+    global $config;
     include_once 'random_string.php';
     $STRING = random_string(6, $alfabet);
 

--- a/website/obserwuj.php
+++ b/website/obserwuj.php
@@ -11,7 +11,6 @@ $g_list = $_GET['list'];
 
 // --------- obsluga dodawania/usuwania obserwatorow ---------
 if (ctype_digit($g_id)) {
-    include_once 'templates/konfig.php';
     include 'longin_chceck.php';
 
     $longin_status = longin_chceck();
@@ -59,7 +58,6 @@ if (ctype_digit($g_id)) {
 // --------- obsluga listowania obserwatorow ---------
 else {
     if (ctype_digit($g_list)) {
-        include_once 'templates/konfig.php';
         $link = DBConnect();
 
         $TRESC = "<div style='background:#ececec; width:400px; padding:15px;'>

--- a/website/ostatnie_obrazki_uzytkownika.php
+++ b/website/ostatnie_obrazki_uzytkownika.php
@@ -9,7 +9,6 @@ $longin_status = longin_chceck();
 $userid = $longin_status['userid'];
 
 if (isset($userid) && is_numeric($userid)) {
-    include_once 'templates/konfig.php';    // config
     $link = DBConnect();
 
     $sql = "SELECT `plik`, `opis` FROM `gk-obrazki` WHERE `user`='$userid' GROUP BY `plik` order by `timestamp` DESC limit 10";

--- a/website/recent_comments_fn.php
+++ b/website/recent_comments_fn.php
@@ -3,7 +3,7 @@
 // display table with recent comments
 
 function recent_comments($where, $limit, $title = '', $zapytanie = '', $showheaders = 0, $emailversion = 0) {
-    include_once 'templates/konfig.php';    // config
+    global $config;
     include 'cotozalog.php';
     include_once 'gc_search_link.php';
     // include_once("longin_chceck.php");

--- a/website/recent_moves.php
+++ b/website/recent_moves.php
@@ -3,7 +3,7 @@
 // display table with recent moves
 
 function recent_moves($where, $limit, $title = '', $zapytanie = '', $showheaders = 0, $emailversion = 0) {
-    include_once 'templates/konfig.php';    // config
+    global $config;
     include 'cotozalog.php';
     include_once 'gc_search_link.php';
     include_once 'days_ago.php';

--- a/website/recent_newscomments_fn.php
+++ b/website/recent_newscomments_fn.php
@@ -3,7 +3,7 @@
 // display recent news comments
 
 function recent_newscomments($where = '', $title = '', $zapytanie = '', $shownewstitles = 0, $emailversion = 0) {
-    include_once 'templates/konfig.php';    // config
+    global $config;
 
     $word_comments = _('View all comments');
 

--- a/website/register.fn.php
+++ b/website/register.fn.php
@@ -3,8 +3,6 @@
 function registerNewGeoKret($kret_nazwa, $kret_opis, $owner_id, $kret_typ, $aktualizuj = true, &$trackingcode = '', $trackingcode_prefix = '', $trackingcode_randomcount = 6, $trackingcode_suffix = '', $trackingcode_alphabet = '') {
     $MAX_TRIES = 100;
 
-    include_once 'templates/konfig.php';
-
     // ----- Check if db object is present, if not create one -----
     if (is_object($GLOBALS['db']) && get_class($GLOBALS['db']) === 'db') {
         $db = $GLOBALS['db'];

--- a/website/templates/plugins/function.login_check.php
+++ b/website/templates/plugins/function.login_check.php
@@ -9,11 +9,11 @@ function login_check() {
         $sessid = $_COOKIE['geokret0'];
     }
 
+    global $config;
+
     if (empty($sessid)) {
         $ERR = 1;
     } else {
-        include_once 'templates/konfig.php';
-
         $link = DBConnect();
 
         // session id chceck

--- a/website/timeline.php
+++ b/website/timeline.php
@@ -3,7 +3,6 @@
 // drawing timeline
 
 function rysuj_timeline($kretid) {
-    include_once 'templates/konfig.php';
     $link = DBConnect();
 
     include 'tools/wykresy/jpgraph/jpgraph.php';

--- a/website/verify_mail.php
+++ b/website/verify_mail.php
@@ -93,7 +93,6 @@ function read_verification_code($kod) {
 
 /// wsysyła maila z kodem i wsadza go do bazy.
 function verify_mail_send($email, $userid, $subject = '', $msg = '') {
-    include_once 'templates/konfig.php';
     // ----- Check if db object is present, if not create one -----
     if (is_object($GLOBALS['db']) && get_class($GLOBALS['db']) === 'db') {
         $db = $GLOBALS['db'];
@@ -102,6 +101,7 @@ function verify_mail_send($email, $userid, $subject = '', $msg = '') {
         $db = new db();
     }
     // ------------------------------------------------------------
+    global $config;
 
     $kod = get_verification_code($userid);
     $db->exec_num_rows("INSERT INTO `gk-aktywnemaile` (`kod`, `userid`, `email`) VALUES ('$kod', '$userid', '$email')", $num_rows, 0, 'Failed to insert verification code into DB', 7, 'verify_mail');

--- a/website/whoiskret.php
+++ b/website/whoiskret.php
@@ -3,8 +3,6 @@
 // identify the kret śćńółż
 
 function whoiskret($id) {
-    include_once 'templates/konfig.php';
-
     $link = DBConnect();
 
     // user chcek

--- a/website/whoiswho.php
+++ b/website/whoiswho.php
@@ -3,8 +3,6 @@
 // identify the user śćńółż
 
 function whoiswho($id) {
-    include_once 'templates/konfig.php';
-
     if ($id == 0) {
         return '(not logged in)';
     } else {

--- a/website/wybierz_jezyk.php
+++ b/website/wybierz_jezyk.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once '__sentry.php';
+global $config_jezyk_encoding;
 
 // Call the user's language
 // search-ajax has the same without include
@@ -17,7 +18,6 @@ elseif (!empty($_COOKIE['geokret1'])) {
 
 else {
     // choose language  according to the browser setting
-    include_once 'templates/konfig.php';    // config
     include 'lang-accept.php';
     $lang = al2gt($config_jezyk_encoding);
 


### PR DESCRIPTION
In our case, include (and now include_once) was used as some
sort of global. This should clean includes a bit. I have used global
where needed, as constants are already present.