### PR TITLE
Feature/gkdb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ git-version
 vars/
 # please use 'composer install' to generate vendor/
 vendor/
+
+execution.log
+website/templates/htmlpurifier/library/HTMLPurifier/DefinitionCache/Serializer/HTML/*.ser

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,35 @@ cache:
 branches:
     except:
     - /\+travis\d+$/
-
 php:
   - 5.6
   - 7.1
   - 7.2
 
+# https://docs.travis-ci.com/user/database-setup/#mariadb
 addons:
+    mariadb: '10.0'
     apt:
         packages:
             - moreutils
             - gettext
 
+# https://docs.travis-ci.com/user/environment-variables/#defining-multiple-variables-per-item
+env:
+    - test_database_host=localhost test_database_pwd= test_show_method_name=true
+
+# https://andidittrich.de/2017/06/travisci-setup-mysql-tablesdata-before-running-tests.html
 before_install:
     - wget --no-verbose https://artifacts.crowdin.com/repo/deb/crowdin.deb -O crowdin.deb
     - sudo dpkg -i crowdin.deb
+    - gkShell/config/testdb/generateSql.sh
+    - mysql -u root --password="" < gkShell/config/testdb/00_database-create-geokrety-db.sql
+    - mysql -u root --password="" < gkShell/config/testdb/01_grant-root.sql
+    - mysql -u root --password="" < gkShell/config/testdb/10_gk-waypointy-country.sql
+    - mysql -u root --password="" < gkShell/config/testdb/11_gk-waypointy-type.sql
+    - tests/config/generateTestConfig.sh
+# mysql  pid file: /var/run/mysqld/mysqld.pid
+# mysql sock file: /var/run/mysqld/mysqld.sock
 
 install:
     - cd website && composer install && cd ..

--- a/docker/mariadb/10_gk-waypointy-country.sql
+++ b/docker/mariadb/10_gk-waypointy-country.sql
@@ -1,3 +1,5 @@
+USE `geokrety-db`;
+
 -- phpMyAdmin SQL Dump
 -- version 4.8.0
 -- https://www.phpmyadmin.net/
@@ -17,8 +19,6 @@ SET time_zone = "+00:00";
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
 /*!40101 SET NAMES utf8mb4 */;
-
-USE `geokrety-db`;
 
 -- --------------------------------------------------------
 

--- a/docker/mariadb/11_gk-waypointy-type.sql
+++ b/docker/mariadb/11_gk-waypointy-type.sql
@@ -1,3 +1,5 @@
+USE `geokrety-db`;
+
 -- phpMyAdmin SQL Dump
 -- version 4.8.0
 -- https://www.phpmyadmin.net/
@@ -17,8 +19,6 @@ SET time_zone = "+00:00";
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
 /*!40101 SET NAMES utf8mb4 */;
-
-USE `geokrety-db`;
 
 -- --------------------------------------------------------
 

--- a/gkShell/README.md
+++ b/gkShell/README.md
@@ -149,6 +149,24 @@ Then to play with geokrety locally, you will run 3 docker containers:
 
 * the script will output you server ip and how to connect to your geokrety instance.
 
+### Run Geokrety tests
+
+If you haven't done it before, update first php dependencies using Composer. *More details on [INSTALL.md](../INSTALL.md)*
+
+````
+    gk composer
+````
+
+Launch the following command (and follow instructions) to create test database
+````
+    gk testdb
+````
+
+Launch the following command to execute phpunit tests
+````
+    gk tests
+````
+
 ### Other commands
 
 To get more commands, execute the following:

--- a/gkShell/config/testdb/.gitignore
+++ b/gkShell/config/testdb/.gitignore
@@ -1,0 +1,3 @@
+# used by gk.sh
+# some sql file may be retrieved from legacy files
+*.sql

--- a/gkShell/config/testdb/__create_prefix
+++ b/gkShell/config/testdb/__create_prefix
@@ -1,0 +1,2 @@
+CREATE DATABASE  IF NOT EXISTS `geokrety-test-db` /*!40100 DEFAULT CHARACTER SET utf8 */;
+USE `geokrety-test-db`;

--- a/gkShell/config/testdb/__use_prefix
+++ b/gkShell/config/testdb/__use_prefix
@@ -1,0 +1,1 @@
+USE `geokrety-test-db`;

--- a/gkShell/config/testdb/createTestDb.sh
+++ b/gkShell/config/testdb/createTestDb.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+echo " * test database creation"
+executeScript() {
+ SCRIPT=$1
+ mysql -u root -B --password="${MYSQL_ROOT_PASSWORD}" < ${SCRIPT} 2>&1 1>>/testdb/execution.log
+}
+echo >/testdb/execution.log
+executeScript /testdb/00_database-create-geokrety-db.sql
+executeScript /testdb/01_grant-root.sql
+executeScript /testdb/10_gk-waypointy-country.sql
+executeScript /testdb/11_gk-waypointy-type.sql

--- a/gkShell/config/testdb/generateSql.sh
+++ b/gkShell/config/testdb/generateSql.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SRC_DIR="${DIR}/../../../docker/mariadb/"
+
+testDb-createPrefix() {
+  targetFile=$1
+  cat "${DIR}/__create_prefix" > "${DIR}/${targetFile}"
+  tail -n +3 "${SRC_DIR}/${targetFile}" >> "${DIR}/${targetFile}"
+}
+testDb-usePrefix() {
+  targetFile=$1
+  cat "${DIR}/__use_prefix" > "${DIR}/${targetFile}"
+  tail -n +3 "${SRC_DIR}/${targetFile}" >> "${DIR}/${targetFile}"
+}
+
+testDb-createPrefix "00_database-create-geokrety-db.sql"
+cp "${SRC_DIR}/01_grant-root.sql" "${DIR}/"
+testDb-usePrefix "10_gk-waypointy-country.sql"
+testDb-usePrefix "11_gk-waypointy-type.sql"

--- a/gkShell/docker-compose.yml
+++ b/gkShell/docker-compose.yml
@@ -9,6 +9,7 @@ services:
             - 3306:3306
         volumes:
             - /gkConfig/mariadb/:/docker-entrypoint-initdb.d:ro
+            - /gkConfig/testdb:/testdb
         environment:
             - TIME_ZONE=UTC
             - MYSQL_ROOT_PASSWORD

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-        bootstrap="./vendor/autoload.php"
+        bootstrap="tests/bootstrap.php"
         colors="true"
         convertErrorsToExceptions="true"
         convertNoticesToExceptions="true"

--- a/tests/01_LDHelperTest.php
+++ b/tests/01_LDHelperTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
-class LDHelperTest extends TestCase {
+class LDHelperTest extends GKTestCase {
     const LD_JSON_SCRIPT_START = '<script type="application/ld+json">';
     const LD_JSON_SCRIPT_END = '</script>';
     const KEYWORDS_EXAMPLE = 'this,is,a,test';
@@ -10,7 +8,8 @@ class LDHelperTest extends TestCase {
     public function test_generate_ld_json_article() {
         // GIVEN
         $ldHelper = new LDHelper('geokrety.org', 'https://geokrety.org', 'https://cdn.geokrety.org/images/banners/geokrety.png');
-        $testDate = date('c', 12345000);
+        $testDate = date('c', 1355310732);
+        $expectedDate = '2012-12-12T12:12:12+01:00';
 
         // WHEN
         $ldJSONArticle = $ldHelper->helpArticle(
@@ -35,8 +34,8 @@ class LDHelperTest extends TestCase {
         .'"mainEntityOfPage":"http:\/\/exemple.com\/",'
         .'"url":"http:\/\/exemple.com\/article.html",'
         .'"author":{"@type":"Person","sameAs":"https:\/\/geokrety.org","name":"geokrety.org"},'
-        .'"dateModified":"1970-05-23T21:10:00+00:00",'
-        .'"datePublished":"1970-05-23T21:10:00+00:00",'
+        .'"dateModified":"'.$expectedDate.'",'
+        .'"datePublished":"'.$expectedDate.'",'
         .'"headline":"this is a test",'
         .'"inLanguage":"fr",'
         .'"keywords":"this,is,a,test",'
@@ -51,7 +50,8 @@ class LDHelperTest extends TestCase {
     public function test_generate_ld_json_website() {
         // GIVEN
         $ldHelper = new LDHelper('geokrety.org', 'https://geokrety.org', 'https://cdn.geokrety.org/images/banners/geokrety.png');
-        $testDate = date('c', 12345000);
+        $testDate = date('c', 1355310732);
+        $expectedDate = '2012-12-12T12:12:12+01:00';
 
         // WHEN
         // ($headline, $description, $imageUrl, $name, $siteUrl, $keywords)
@@ -80,7 +80,7 @@ class LDHelperTest extends TestCase {
         .'"publisher":{"@type":"Organization","name":"geokrety.org","url":"https:\/\/geokrety.org",'
           .'"logo":{"@type":"ImageObject","url":"https:\/\/cdn.geokrety.org\/images\/banners\/geokrety.png"}},'
         .'"keywords":"'.self::KEYWORDS_EXAMPLE.'",'
-        .'"inLanguage":"fr","dateModified":"1970-05-23T21:10:00+00:00","datePublished":"1970-05-23T21:10:00+00:00"'
+        .'"inLanguage":"fr","dateModified":"'.$expectedDate.'","datePublished":"'.$expectedDate.'"'
         .'}'
         .self::LD_JSON_SCRIPT_END;
 
@@ -96,7 +96,7 @@ class LDHelperTest extends TestCase {
         $konkret->url = 'https://example.com/konkret.php';
         $konkret->author = 'Jojo';
         $konkret->authorUrl = 'https://example.com/author.php?name=Jojo';
-        $konkret->datePublished = date('c', 12345000);
+        $konkret->datePublished = date('c', 1355310732);
         $konkret->imageUrl = 'https://example.com/konkret.jpg';
         $konkret->keywords = self::KEYWORDS_EXAMPLE;
         $konkret->ratingCount = 10;
@@ -105,13 +105,13 @@ class LDHelperTest extends TestCase {
         $log1 = new \Geokrety\Domain\KonkretLog();
         $log1->authorName = 'George';
         $log1->authorUrl = 'https://example.com/author.php?name=George';
-        $log1->dateCreated = date('c', 12345000);
+        $log1->dateCreated = date('c', 1355310732);
         $log1->text = 'log1 content';
 
         $log2 = new \Geokrety\Domain\KonkretLog();
         $log2->authorName = 'Robert';
         $log2->authorUrl = 'https://example.com/author.php?name=Robert';
-        $log2->dateCreated = date('c', 12345000);
+        $log2->dateCreated = date('c', 1355310732);
         $log2->text = 'log2 content here';
 
         $konkretLogs = array($log1, $log2);
@@ -122,6 +122,7 @@ class LDHelperTest extends TestCase {
         $ldJSONWebSite = $ldHelper->helpKonkret($konkret);
 
         // THEN
+        $expectedDate = '2012-12-12T12:12:12+01:00';
         $expectedResult = self::LD_JSON_SCRIPT_START
         .'{'
         .'"@context":"http:\/\/schema.org",'
@@ -139,7 +140,7 @@ class LDHelperTest extends TestCase {
                                     .'"sameAs":"https:\/\/example.com\/author.php?name=George",'
                                     .'"name":"George"'
                                 .'},'
-                                .'"dateCreated":"1970-05-23T21:10:00+00:00",'
+                                .'"dateCreated":"'.$expectedDate.'",'
                                 .'"text":"log1 content"'
                             .'},{'
                                 .'"@type":"Comment",'
@@ -148,12 +149,12 @@ class LDHelperTest extends TestCase {
                                     .'"sameAs":"https:\/\/example.com\/author.php?name=Robert",'
                                     .'"name":"Robert"'
                                 .'},'
-                                .'"dateCreated":"1970-05-23T21:10:00+00:00",'
+                                .'"dateCreated":"'.$expectedDate.'",'
                                 .'"text":"log2 content here"'
                             .'}'
         .'],'
         .'"commentCount":2,'
-        .'"datePublished":"1970-05-23T21:10:00+00:00",'
+        .'"datePublished":"'.$expectedDate.'",'
         .'"keywords":"'.self::KEYWORDS_EXAMPLE.'",'
         .'"publisher":{"@type":"Organization","name":"geokrety.org","url":"https:\/\/geokrety.org","logo":{"@type":"ImageObject","url":"https:\/\/cdn.geokrety.org\/images\/banners\/geokrety.png"}}'
         .'}'

--- a/tests/02_CreditsTest.php
+++ b/tests/02_CreditsTest.php
@@ -1,15 +1,12 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
 /**
  * @SuppressWarnings(PHPMD.UnusedLocalVariable)
  */
-class CreditsTest extends TestCase {
+class CreditsTest extends GKTestCase {
     public function test_generate_credits() {
         // GIVEN
-        define('CONFIG_CDN_LOGOS', 'https://cdn.geokrety.org/images/logos/');
-        require_once 'website/templates/konfig-credits.php';
+        include 'website/templates/konfig-credits.php';
         $credits = new \Geokrety\View\Credits($config['gk_credits']);
 
         // WHEN
@@ -21,6 +18,6 @@ class CreditsTest extends TestCase {
         $this->assertGreaterThan(0, $creditsCount, 'please define one or more credits into konfig-credits');
 
         $this->assertNotNull($creditsDivs);
-        $this->assertTrue($testUtil->isValidHtmlContent($creditsDivs), 'credits divs: must be valid html content');
+        $this->assertTrue($testUtil->isValidHtmlContent($creditsDivs), 'credits divs invalid html content');
     }
 }

--- a/tests/03_SocialGroupsTest.php
+++ b/tests/03_SocialGroupsTest.php
@@ -1,14 +1,12 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
 /**
  * @SuppressWarnings(PHPMD.UnusedLocalVariable)
  */
-class SocialGroupsTest extends TestCase {
+class SocialGroupsTest extends GKTestCase {
     public function test_generate_social_groups() {
         // GIVEN
-        require_once 'website/templates/konfig-groups.php';
+        include 'website/templates/konfig-groups.php';
         $socialGroups = new \Geokrety\View\SocialGroups($config['gk_social_groups']);
 
         // WHEN
@@ -20,6 +18,6 @@ class SocialGroupsTest extends TestCase {
         $this->assertGreaterThan(0, $groupsCount, 'please define one or more social groups into konfig-groups');
 
         $this->assertNotNull($groupsTable);
-        $this->assertTrue($testUtil->isValidHtmlContent($groupsTable), 'social groups table: must be valid html content');
+        $this->assertTrue($testUtil->isValidHtmlContent($groupsTable), 'social groups table invalid html content');
     }
 }

--- a/tests/D00_GKDBTest.php
+++ b/tests/D00_GKDBTest.php
@@ -1,0 +1,67 @@
+<?php
+
+class GKDBTest extends GKTestCase {
+    public function setUp() {
+        parent::setUp();
+        $this->assumeTestDatabase();
+    }
+
+    public function test_should_get_database_link() {
+        // GIVEN
+        // WHEN
+        $database = DBConnect();
+
+        // THEN
+        $this->assertTrue(($database == true));
+        $this->assertSingleConnectCount();
+    }
+
+    public function test_should_get_working_database_query() {
+        // GIVEN
+        $database = DBConnect();
+        $sql = 'SELECT * FROM `gk-waypointy-type` LIMIT 50';
+
+        // WHEN
+        $result = mysqli_query($database, $sql);
+        $row_cnt = $result->num_rows;
+        mysqli_free_result($result);
+
+        // THEN
+        $this->assertSame($row_cnt, 50, 'expect to get 50 gk-waypointy-type');
+        $this->assertSingleConnectCount();
+    }
+
+    public function test_should_get_single_database_link() {
+        // GIVEN
+        $database = DBConnect();
+        $database = null;
+
+        // WHEN
+        $database = DBConnect();
+
+        // THEN
+        $this->assertTrue(($database == true));
+        $this->assertSingleConnectCount();
+    }
+
+    public function test_should_reconnect_database_link() {
+        // GIVEN
+        $database = DBConnect();
+        $database->close();
+
+        // WHEN
+        $database = DBConnect();
+
+        // THEN
+        $this->assertTrue(($database == true));
+        $this->assertConnectCount(2);
+    }
+
+    private function assertSingleConnectCount() {
+        $this->assertConnectCount(1);
+    }
+
+    private function assertConnectCount($expectedCount) {
+        $this->assertSame(GKDB::getConnectCount(), $expectedCount, 'expect one db connect over the time');
+    }
+}

--- a/tests/D01_RecentMovesTest.php
+++ b/tests/D01_RecentMovesTest.php
@@ -1,0 +1,21 @@
+<?php
+
+class RecentMovesTest extends GKTestCase {
+    public function setUp() {
+        parent::setUp();
+        $this->assumeTestDatabase();
+    }
+
+    public function test_recent_moves() {
+        // GIVEN
+        include_once 'website/recent_moves.php';
+
+        // WHEN
+        $result = recent_moves('', 50, '', '', true);
+
+        // THEN
+        $testUtil = new TestUtil();
+        $this->assertNotNull($result);
+        $this->assertTrue($testUtil->isValidHtmlContent($result), 'recent moves invalid html content');
+    }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,48 @@
+This page describes how to test Geokrety using PHPUnit
+
+# Context
+
+PHPUnit is a PHP Unit Tests framework
+
+Main config file is at root location and called `phpunit.xml`
+
+## Minimal requirements
+
+You will need some php extensions:
+
+Uncomment in `php.ini` your extension location:
+
+    extension_dir = "C:/tools/php7/ext/" or "ext"
+
+and enable the following extensions:
+
+    extension=curl
+    extension=gettext
+    extension=mysqli
+
+## Test customization
+
+Some tests requires database, but without test database defined, this tests are simply skipped.
+To setup test database, fill the following environment: `test_database_host`, `test_database_pwd`
+
+Main tests config file is: `tests\config\konfig-mysql.php`.
+Notice that database name is `geokrety-test-db` and user is `root`. 
+
+You could also show test methods by setting: `test_show_method_name=true`
+
+
+## How to run tests
+
+Example of a Bash configuration:
+
+    Name: PHPUnit (geokrety)
+    Script: scripts/runTests.sh
+    Interpreter path: C:\Programmes\Git\bin\bash.exe
+    Working directory: C:\MyWORK\geokrety-website
+
+In option, you could add environment variables to customize your tests:
+
+
+    test_database_host=gk-db
+    test_database_pwd=password
+    test_show_method_name=true

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,14 @@
+<?php
+ include './vendor/autoload.php';
+
+ $testConfig = dirname(__FILE__).DIRECTORY_SEPARATOR.'config';
+ putenv("website_config_directory=$testConfig");
+
+ echo "\n bootstrap - config:$testConfig\n";
+ $dbFile = $testConfig.DIRECTORY_SEPARATOR.'konfig-local.php';
+ if (!file_exists($dbFile)) {
+     echo ' XXX Test config expected '.$dbFile."\n";
+     echo "     please run generateTestConfig.sh\n";
+     die;
+ }
+ require_once 'website/templates/konfig.php';

--- a/tests/config/.gitignore
+++ b/tests/config/.gitignore
@@ -1,0 +1,4 @@
+# used by test
+# some file may be retrieved from legacy templates
+konfig-local.php
+ssmtp.conf

--- a/tests/config/generateTestConfig.sh
+++ b/tests/config/generateTestConfig.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SRC_DIR="${DIR}/../../configs/"
+
+cp "${SRC_DIR}/konfig-local.tmpl.php" "${DIR}/konfig-local.php"
+cp "${SRC_DIR}/ssmtp.tmpl.conf" "${DIR}/ssmtp.conf"

--- a/tests/config/konfig-mysql.php
+++ b/tests/config/konfig-mysql.php
@@ -1,0 +1,9 @@
+<?php
+
+// MySQL config
+
+$config['host'] = getenv('test_database_host');
+$config['username'] = 'root';
+$config['pass'] = getenv('test_database_pwd');
+$config['db'] = 'geokrety-test-db';
+$config['charset'] = 'utf8';

--- a/tests/lib/GKTestCase.php
+++ b/tests/lib/GKTestCase.php
@@ -1,0 +1,31 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+abstract class GKTestCase extends TestCase {
+    protected $hasDatabase = false;
+
+    protected $preserveGlobalState = false;
+    // protected $runTestInSeparateProcess = TRUE;
+
+    public static function setUpBeforeClass() {
+    }
+
+    public function __construct() {
+        if (getenv('test_database_host')) {
+            $this->hasDatabase = true;
+        }
+    }
+
+    public function setUp() {
+        if (getenv('test_show_method_name') == 'true') {
+            fwrite(STDOUT, get_class($this).' :: '.$this->getName()."\n\n");
+        }
+    }
+
+    public function assumeTestDatabase() {
+        if (!$this->hasDatabase) {
+            $this->markTestIncomplete('test database needed');
+        }
+    }
+}

--- a/website/index.php
+++ b/website/index.php
@@ -2,78 +2,78 @@
 
 require_once '__sentry.php';
 
-// Main page of GeoKrety śćńółżł
-// parametry:
-// debugecho=1 -> wyswietla stopery
+try {
+    // Main page of GeoKrety śćńółżł
+    // parametry:
+    // debugecho=1 -> wyswietla stopery
 
-$speedtest_index = $_GET['debugecho'];
-$speedtest_index_maxtime = 5;
-$debugecho_index = $_GET['debugecho'];
-if ($speedtest_index) {
-    include_once 'speedtest.php';
-    $st_index = new SpeedTest();
-    include_once 'defektoskop.php';
-}
-
-// ***************
-if ($speedtest_index) {
-    $ST1 = 'start';
-    $ST2 = $st_index->stop_show_start();
-    $ST3 = 'ST='.$ST2.'s - '.$ST1;
-    if ($ST2 > $speedtest_index_maxtime) {
-        errory_add($ST3, 50);
+    $speedtest_index = $_GET['debugecho'];
+    $speedtest_index_maxtime = 5;
+    $debugecho_index = $_GET['debugecho'];
+    if ($speedtest_index) {
+        $st_index = new SpeedTest();
+        include_once 'defektoskop.php';
     }
-    if ($debugecho_index) {
-        echo $ST3.'<br/>';
-    }
-}
-// ***************
 
-// smarty cache
+    // ***************
+    if ($speedtest_index) {
+        $ST1 = 'start';
+        $ST2 = $st_index->stop_show_start();
+        $ST3 = 'ST='.$ST2.'s - '.$ST1;
+        if ($ST2 > $speedtest_index_maxtime) {
+            errory_add($ST3, 50);
+        }
+        if ($debugecho_index) {
+            echo $ST3.'<br/>';
+        }
+    }
+    // ***************
+
+    // smarty cache
 $smarty_cache_this_page = ($_GET['debugecho'] == 1 ? 0 : 600); // this page should be cached for n seconds, unless debugecho=1 parameter exists
 $smarty_cache_this_page = 0;
-require_once 'smarty_start.php';
+    require_once 'smarty_start.php';
 
-$TYTUL = _('Home');
-$HEAD = '<meta http-equiv="Cache-Control" content="max-age=600"/>';
+    $TYTUL = _('Home');
+    $HEAD = '<meta http-equiv="Cache-Control" content="max-age=600"/>';
 
-require_once 'szukaj_kreta.php';
-require_once 'recent_moves.php';
-require_once 'recent_pictures.php';
-require_once 'ulicznik.php'; //counter
+    require_once 'szukaj_kreta.php';
+    require_once 'recent_moves.php';
+    require_once 'recent_pictures.php';
+    require_once 'ulicznik.php'; //counter
 
-// ***************
-if ($speedtest_index) {
-    $ST1 = 'includy';
-    $ST2 = $st_index->stop_show_start();
-    $ST3 = 'ST='.$ST2.'s - '.$ST1;
-    if ($ST2 > $speedtest_index_maxtime) {
-        errory_add($ST3, 50);
+    // ***************
+    if ($speedtest_index) {
+        $ST1 = 'includy';
+        $ST2 = $st_index->stop_show_start();
+        $ST3 = 'ST='.$ST2.'s - '.$ST1;
+        if ($ST2 > $speedtest_index_maxtime) {
+            errory_add($ST3, 50);
+        }
+        if ($debugecho_index) {
+            echo $ST3.'<br/>';
+        }
     }
-    if ($debugecho_index) {
-        echo $ST3.'<br/>';
+    // ***************
+
+    $link = GKDB::getLink();
+
+    $ulicznik = ulicznik('index');
+
+    $OGON .= '<script type="text/javascript" src="'.$config['ajaxtooltip.js'].'"></script>';
+    $OGON .= '<script type="text/javascript" src="'.CONFIG_CDN_LIBRARIES.'/lytebox/lytebox.min.js"></script>';
+    $HEAD .= '<link rel="stylesheet" href="'.CONFIG_CDN_LIBRARIES.'/lytebox/lytebox.css" type="text/css" media="screen" />';
+    $HEAD .= '<style type="text/css">.temptip TD{font-size: 8pt; padding:0px 2px 0px 2px; background: lightyellow;}</style>';
+
+    // -------------------------------------- statystyki podstawowe / basic statistics -------------- //
+
+    $result = mysqli_query($link, "SELECT * FROM `gk-wartosci` WHERE `name` LIKE 'stat_%'");
+    while ($row = mysqli_fetch_assoc($result)) {
+        $statystyka[$row['name']] = $row['value'];
     }
-}
-// ***************
+    mysqli_free_result($result);
 
-$link = DBConnect();
-
-$ulicznik = ulicznik('index');
-
-$OGON .= '<script type="text/javascript" src="'.$config['ajaxtooltip.js'].'"></script>';
-$OGON .= '<script type="text/javascript" src="'.CONFIG_CDN_LIBRARIES.'/lytebox/lytebox.min.js"></script>';
-$HEAD .= '<link rel="stylesheet" href="'.CONFIG_CDN_LIBRARIES.'/lytebox/lytebox.css" type="text/css" media="screen" />';
-$HEAD .= '<style type="text/css">.temptip TD{font-size: 8pt; padding:0px 2px 0px 2px; background: lightyellow;}</style>';
-
-// -------------------------------------- statystyki podstawowe / basic statistics -------------- //
-
-$result = mysqli_query($link, "SELECT * FROM `gk-wartosci` WHERE `name` LIKE 'stat_%'");
-while ($row = mysqli_fetch_assoc($result)) {
-    $statystyka[$row['name']] = $row['value'];
-}
-mysqli_free_result($result);
-
-$OGON .= "<script>
+    $OGON .= "<script>
 $(function () {
   $('#nr[maxlength]').maxlength({
     warningClass: \"label label-danger\",
@@ -81,11 +81,11 @@ $(function () {
   });
 })
 </script>\n";
-$userid_longin = $longin_status['userid'];
-if (in_array($userid_longin, $config['superusers'])) {
-    $TRESC .= '<div style="float: right;"><img class="menu-lab16" src="'.CONFIG_CDN_IMAGES.'/icons/diaspora.png" alt="*" /><a href="_admin.php">'._('admin').'</a></div>';
-}
-$TRESC .= '
+    $userid_longin = $longin_status['userid'];
+    if (in_array($userid_longin, $config['superusers'])) {
+        $TRESC .= '<div style="float: right;"><img class="menu-lab16" src="'.CONFIG_CDN_IMAGES.'/icons/diaspora.png" alt="*" /><a href="_admin.php">'._('admin').'</a></div>';
+    }
+    $TRESC .= '
 <h2>'._('Welcome to GeoKrety.org!').'</h2>
 <div class="row" id="welcome_intro">
   <div class="col-md-9">
@@ -133,31 +133,31 @@ $TRESC .= '
 </div>
 ';
 
-// ***************
-if ($speedtest_index) {
-    $ST1 = 'liczniki';
-    $ST2 = $st_index->stop_show_start();
-    $ST3 = 'ST='.$ST2.'s - '.$ST1;
-    if ($ST2 > $speedtest_index_maxtime) {
-        errory_add($ST3, 50);
+    // ***************
+    if ($speedtest_index) {
+        $ST1 = 'liczniki';
+        $ST2 = $st_index->stop_show_start();
+        $ST3 = 'ST='.$ST2.'s - '.$ST1;
+        if ($ST2 > $speedtest_index_maxtime) {
+            errory_add($ST3, 50);
+        }
+        if ($debugecho_index) {
+            echo $ST3.'<br/>';
+        }
     }
-    if ($debugecho_index) {
-        echo $ST3.'<br/>';
-    }
-}
-// ***************
+    // ***************
 
-// -------------------------------------- news ------------------------------- //
+    // -------------------------------------- news ------------------------------- //
 
-$TRESC .= '<h2>'._('News').'</h2>';
-$TRESC .= '<div id="welcome_new">';
+    $TRESC .= '<h2>'._('News').'</h2>';
+    $TRESC .= '<div id="welcome_new">';
 
-$sql = 'SELECT DATE(`date`), `tresc`, `tytul`, `who`, `userid`, `komentarze`, `news_id` FROM `gk-news` ORDER BY `date` DESC LIMIT 2';
-$result = mysqli_query($link, $sql);
+    $sql = 'SELECT DATE(`date`), `tresc`, `tytul`, `who`, `userid`, `komentarze`, `news_id` FROM `gk-news` ORDER BY `date` DESC LIMIT 2';
+    $result = mysqli_query($link, $sql);
 
-while ($row = mysqli_fetch_array($result)) {
-    list($date, $tresc, $tytul, $who, $userid, $komentarze, $newsid) = $row;
-    $TRESC .= '<div class="panel panel-default">
+    while ($row = mysqli_fetch_array($result)) {
+        list($date, $tresc, $tytul, $who, $userid, $komentarze, $newsid) = $row;
+        $TRESC .= '<div class="panel panel-default">
       <div class="panel-heading">
         <div class="panel-title pull-left">
           <h3 class="panel-title">'.$tytul.'</h3>
@@ -172,27 +172,27 @@ while ($row = mysqli_fetch_array($result)) {
       </div>
       <div class="panel-body">'.$tresc.'</div>
     </div>';
-}
-unset($date, $tresc, $tytul, $who, $userid, $row);
-$TRESC .= '</div>';
-// ***************
-if ($speedtest_index) {
-    $ST1 = 'news';
-    $ST2 = $st_index->stop_show_start();
-    $ST3 = 'ST='.$ST2.'s - '.$ST1;
-    if ($ST2 > $speedtest_index_maxtime) {
-        errory_add($ST3, 50);
     }
-    if ($debugecho_index) {
-        echo $ST3.'<br/>';
+    unset($date, $tresc, $tytul, $who, $userid, $row);
+    $TRESC .= '</div>';
+    // ***************
+    if ($speedtest_index) {
+        $ST1 = 'news';
+        $ST2 = $st_index->stop_show_start();
+        $ST3 = 'ST='.$ST2.'s - '.$ST1;
+        if ($ST2 > $speedtest_index_maxtime) {
+            errory_add($ST3, 50);
+        }
+        if ($debugecho_index) {
+            echo $ST3.'<br/>';
+        }
     }
-}
-// ***************
+    // ***************
 
-// -------------------------------------- recent moves ------------------------------- //
+    // -------------------------------------- recent moves ------------------------------- //
 
-//$TRESC .= recent_moves("WHERE (gk.typ = '0' OR gk.typ = '1')", 7);
-$TRESC .= recent_moves(
+    //$TRESC .= recent_moves("WHERE (gk.typ = '0' OR gk.typ = '1')", 7);
+    $TRESC .= recent_moves(
     '', 7, '', "
 		SELECT	ru.ruch_id, ru.id, ru.lat, ru.lon, ru.country, ru.waypoint, ru.droga, ru.data, ru.user,
 				ru.koment, ru.logtype, ru.username, us.user, gk.nazwa, gk.typ, gk.owner, pic.plik, ru.zdjecia
@@ -205,107 +205,107 @@ $TRESC .= recent_moves(
 		ORDER BY ru.ruch_id DESC limit 7
 "
 );
-$TRESC .= '<div style="margin-top: 10px; text-align: right">'."<a href='mapki/google_static_logs.png' class='att_js' title='ajax|2|mapki/google_static_logs.png'>"._('Recent logs on the map').'</a>'.'</div>';
-// ***************
-if ($speedtest_index) {
-    $ST1 = 'recent moves';
-    $ST2 = $st_index->stop_show_start();
-    $ST3 = 'ST='.$ST2.'s - '.$ST1;
-    if ($ST2 > $speedtest_index_maxtime) {
-        errory_add($ST3, 50);
+    $TRESC .= '<div style="margin-top: 10px; text-align: right">'."<a href='mapki/google_static_logs.png' class='att_js' title='ajax|2|mapki/google_static_logs.png'>"._('Recent logs on the map').'</a>'.'</div>';
+    // ***************
+    if ($speedtest_index) {
+        $ST1 = 'recent moves';
+        $ST2 = $st_index->stop_show_start();
+        $ST3 = 'ST='.$ST2.'s - '.$ST1;
+        if ($ST2 > $speedtest_index_maxtime) {
+            errory_add($ST3, 50);
+        }
+        if ($debugecho_index) {
+            echo $ST3.'<br/>';
+        }
     }
-    if ($debugecho_index) {
-        echo $ST3.'<br/>';
-    }
-}
-// ***************
+    // ***************
 
-// -------------------------------------- recent pictures ------------------------------- //
+    // -------------------------------------- recent pictures ------------------------------- //
 
-$TRESC .= '<h2>'._('Recently uploaded images').'</h2>
+    $TRESC .= '<h2>'._('Recently uploaded images').'</h2>
 <table id="recent_pictures_table"><tr><td>';
-$TRESC .= recent_pictures('LIMIT 10');
-$TRESC .= '</td></tr><tr><td align="right"><a href="galeria.php">'._('Photo gallery').' >>></a></td></tr></table>';
-// ***************
-if ($speedtest_index) {
-    $ST1 = 'pictures';
-    $ST2 = $st_index->stop_show_start();
-    $ST3 = 'ST='.$ST2.'s - '.$ST1;
-    if ($ST2 > $speedtest_index_maxtime) {
-        errory_add($ST3, 50);
+    $TRESC .= recent_pictures('LIMIT 10');
+    $TRESC .= '</td></tr><tr><td align="right"><a href="galeria.php">'._('Photo gallery').' >>></a></td></tr></table>';
+    // ***************
+    if ($speedtest_index) {
+        $ST1 = 'pictures';
+        $ST2 = $st_index->stop_show_start();
+        $ST3 = 'ST='.$ST2.'s - '.$ST1;
+        if ($ST2 > $speedtest_index_maxtime) {
+            errory_add($ST3, 50);
+        }
+        if ($debugecho_index) {
+            echo $ST3.'<br/>';
+        }
     }
-    if ($debugecho_index) {
-        echo $ST3.'<br/>';
+    // ***************
+
+    // -------------------------------------- recent geokrets ------------------------------- //
+
+    $TRESC .= szukaj_kreta(' WHERE `gk-geokrety`.`owner` > 0 ', 7, _('Recently registered GeoKrets'), '');
+    // ***************
+    if ($speedtest_index) {
+        $ST1 = 'geokrets';
+        $ST2 = $st_index->stop_show_start();
+        $ST3 = 'ST='.$ST2.'s - '.$ST1;
+        if ($ST2 > $speedtest_index_maxtime) {
+            errory_add($ST3, 50);
+        }
+        if ($debugecho_index) {
+            echo $ST3.'<br/>';
+        }
     }
-}
-// ***************
+    // ***************
 
-// -------------------------------------- recent geokrets ------------------------------- //
+    // ---- kto online ----//
 
-$TRESC .= szukaj_kreta(' WHERE `gk-geokrety`.`owner` > 0 ', 7, _('Recently registered GeoKrets'), '');
-// ***************
-if ($speedtest_index) {
-    $ST1 = 'geokrets';
-    $ST2 = $st_index->stop_show_start();
-    $ST3 = 'ST='.$ST2.'s - '.$ST1;
-    if ($ST2 > $speedtest_index_maxtime) {
-        errory_add($ST3, 50);
+    $TRESC .= '<div style="margin-top: 1em;" class="xs" id="online_users">'._('Online users').': ';
+
+    $link->query("SET time_zone = '+0:00'");
+    $sql = 'SELECT `user`, `userid` FROM `gk-users` WHERE `ostatni_login` > DATE_SUB(NOW(), INTERVAL 5 MINUTE)';
+    $result = mysqli_query($link, $sql);
+
+    while ($row = mysqli_fetch_array($result)) {
+        list($user, $userid) = $row;
+        $TRESC .= "<a href=\"/mypage.php?userid=$userid\">$user</a> ";
     }
-    if ($debugecho_index) {
-        echo $ST3.'<br/>';
-    }
-}
-// ***************
 
-// ---- kto online ----//
-
-$TRESC .= '<div style="margin-top: 1em;" class="xs" id="online_users">'._('Online users').': ';
-
-$link->query("SET time_zone = '+0:00'");
-$sql = 'SELECT `user`, `userid` FROM `gk-users` WHERE `ostatni_login` > DATE_SUB(NOW(), INTERVAL 5 MINUTE)';
-$result = mysqli_query($link, $sql);
-
-while ($row = mysqli_fetch_array($result)) {
-    list($user, $userid) = $row;
-    $TRESC .= "<a href=\"/mypage.php?userid=$userid\">$user</a> ";
-}
-
-$TRESC .= '<p>
+    $TRESC .= '<p>
 <img src="'.CONFIG_CDN_IMAGES.'/icons/question.png" alt="down" width="16" height="16" />
 <a href="https://crwd.in/geokrety">'._('Join our translation team').'</a> | <a href="lang.php?lang=zu_ZA.UTF-8">'._('Suggest a better translation - inline')."</a> ($lang)</p><p class='male' align='right'>[$ulicznik[0]] [$ulicznik[1] "._('visits/day').']</p>';
-$TRESC .= '</div>';
-// ***************
-if ($speedtest_index) {
-    $ST1 = 'kto online';
-    $ST2 = $st_index->stop_show_start();
-    $ST3 = 'ST='.$ST2.'s - '.$ST1;
-    if ($ST2 > $speedtest_index_maxtime) {
-        errory_add($ST3, 50);
+    $TRESC .= '</div>';
+    // ***************
+    if ($speedtest_index) {
+        $ST1 = 'kto online';
+        $ST2 = $st_index->stop_show_start();
+        $ST3 = 'ST='.$ST2.'s - '.$ST1;
+        if ($ST2 > $speedtest_index_maxtime) {
+            errory_add($ST3, 50);
+        }
+        if ($debugecho_index) {
+            echo $ST3.'<br/>';
+        }
     }
-    if ($debugecho_index) {
-        echo $ST3.'<br/>';
-    }
-}
-// ***************
+    // ***************
 
-//$TRESC .= '<img src="http://achjoj.info/znak.php?nr=4" alt="x" border="0" height="1" width="1" />';
-//$TRESC .= '<img src="'.CONFIG_CDN_IMAGES.'/log-icons/0/4.png" alt="" width="37" height="37" />';
+    //$TRESC .= '<img src="http://achjoj.info/znak.php?nr=4" alt="x" border="0" height="1" width="1" />';
+    //$TRESC .= '<img src="'.CONFIG_CDN_IMAGES.'/log-icons/0/4.png" alt="" width="37" height="37" />';
 
-// --------------------------------------------------------------- SMARTY ---------------------------------------- //
+    // --------------------------------------------------------------- SMARTY ---------------------------------------- //
 
-// ----------------------------------------------JSON-LD---------------------------
-$gkName = $config['adres'];
-$gkUrl = $config['adres'];
-$gkLogoUrl = $config['cdn_url'].'/images/banners/geokrety.png';
-$gkHeadline = _('Welcome to GeoKrety.org!');
-$gkDescription = _('This service is similar to TravelBug(TM) or GeoLutins and aims at tracking things you put to geocache containers... <a href="help.php#about">read more...</a>');
-$gkKeywords = 'geokrety,opencaching,geocaching,geocoin,geobook,krety,geokret,geokrets,geocache,gps';
-$lastUpdate = filemtime(__FILE__);
-$dateModified = date('c', $helpLastUpdate);
-$datePublished = date('c', $helpLastUpdate);
+    // ----------------------------------------------JSON-LD---------------------------
+    $gkName = $config['adres'];
+    $gkUrl = $config['adres'];
+    $gkLogoUrl = $config['cdn_url'].'/images/banners/geokrety.png';
+    $gkHeadline = _('Welcome to GeoKrety.org!');
+    $gkDescription = _('This service is similar to TravelBug(TM) or GeoLutins and aims at tracking things you put to geocache containers... <a href="help.php#about">read more...</a>');
+    $gkKeywords = 'geokrety,opencaching,geocaching,geocoin,geobook,krety,geokret,geokrets,geocache,gps';
+    $lastUpdate = filemtime(__FILE__);
+    $dateModified = date('c', $helpLastUpdate);
+    $datePublished = date('c', $helpLastUpdate);
 
-$ldHelper = new LDHelper($gkName, $gkUrl, $gkLogoUrl);
-$ldJSONWebSite = $ldHelper->helpWebSite(
+    $ldHelper = new LDHelper($gkName, $gkUrl, $gkLogoUrl);
+    $ldJSONWebSite = $ldHelper->helpWebSite(
     $gkHeadline,
     $gkDescription,
     $gkLogoUrl,
@@ -317,7 +317,10 @@ $ldJSONWebSite = $ldHelper->helpWebSite(
     $datePublished
     );
 
-$TRESC .= $ldJSONWebSite;
-// ----------------------------------------------JSON-LD-(end)---------------------
-require_once 'smarty.php';
-//include_once("gk_cache_end.php");
+    $TRESC .= $ldJSONWebSite;
+    // ----------------------------------------------JSON-LD-(end)---------------------
+    require_once 'smarty.php';
+    //include_once("gk_cache_end.php");
+} catch (Exception $exc) {
+    echo 'Service unavailable - '.$exc->getMessage();
+}

--- a/website/konkret-tabelka.php
+++ b/website/konkret-tabelka.php
@@ -8,7 +8,6 @@ $speedtest_konkret_tabelka = 1;
 $speedtest_konkret_tabelka_maxtime = 2.0;
 $debugecho_konkret_tabelka = $_GET['debugecho'];
 if ($speedtest_konkret_tabelka) {
-    include_once 'speedtest.php';
     $st_konkret_tabelka = new SpeedTest();
     $st_konkret_tabelka_ = new SpeedTest();
     include_once 'defektoskop.php';

--- a/website/konkret.php
+++ b/website/konkret.php
@@ -47,7 +47,7 @@ if (!ctype_digit($kret_id)) {
     exit;
 }
 
-$link = DBConnect();
+$link = GKDB::getLink();
 
 $result = mysqli_query($link,
     "SELECT id, nr, nazwa, opis, owner, us.user, data, typ, droga, skrzynki, zdjecia, avatarid, timestamp_oc

--- a/website/lib/GKDB.class.php
+++ b/website/lib/GKDB.class.php
@@ -1,0 +1,76 @@
+<?php
+
+class GKDB {
+    private static $connectCount = 0;
+    private static $_instance = null;
+
+    private $link = null;
+
+    private function __construct() {
+    }
+
+    public static function getInstance() {
+        if (is_null(self::$_instance)) {
+            self::$_instance = new GKDB();
+        }
+
+        return self::$_instance;
+    }
+
+    public static function getLink() {
+        return self::getInstance()->connect();
+    }
+
+    public static function getConnectCount() {
+        return self::$connectCount;
+    }
+
+    public function connect() {
+        if ($this->link != null) {
+            try {
+                mysqli_get_server_info($this->link);
+
+                return $this->link;
+            } catch (Exception $exc) {
+            }
+        }
+        // DEBUG // echo 'connect '.CONFIG_USERNAME.'@'.CONFIG_HOST.' using '.CONFIG_PASS;
+        try {
+            $this->link = mysqli_connect(CONFIG_HOST, CONFIG_USERNAME, CONFIG_PASS);
+            if (!$this->link) {// lets retry
+                $this->link = mysqli_connect(CONFIG_HOST, CONFIG_USERNAME, CONFIG_PASS);
+                if (!$this->link) {
+                    throw new Exception('Unable to join database server');
+                }
+            }
+            $db_select = mysqli_select_db($this->link, CONFIG_DB);
+            if (!$db_select) {
+                throw new Exception('Unknown database "'.CONFIG_DB.'" : '.mysqli_errno($this->link));
+            }
+            $this->link->set_charset(CONFIG_CHARSET);
+            $this->link->query("SET time_zone = '".CONFIG_TIMEZONE."'");
+            ++self::$connectCount;
+
+            return $this->link;
+        } catch (Exception $exc) {
+            $errorId = uniqid('GKIE_');
+            $errorMessage = 'DB ERROR '.$errorId.' - '.$exc->getMessage();
+            error_log($errorMessage);
+            error_log($exc);
+            $this->link = null; // do not reuse link on error
+            throw new Exception($errorMessage);
+        }
+    }
+
+    public function close() {
+        if (!isset($this->link)) {
+            return;
+        }
+        mysqli_close($this->link);
+        unset($this->link);
+    }
+
+    public function __clone() {
+        throw new Exception("Can't clone a singleton");
+    }
+}

--- a/website/lib/SpeedTest.php
+++ b/website/lib/SpeedTest.php
@@ -1,0 +1,52 @@
+<?php
+
+// script execution time test
+
+/*
+$st=new SpeedTest();
+...
+echo $st->stop_show();
+*/
+
+class SpeedTest {
+    private $start_time;
+    private $end_time;
+
+    public function SpeedTest() {
+        $this->end_time = 0;
+        $this->start_time = $this->getTimestamp();
+    }
+
+    private function getTimestamp() {
+        $now = gettimeofday();
+
+        return $now['sec'] + ($now['usec'] / 1000000);
+    }
+
+    public function start() //called automatically at creation as well
+    {
+        $this->start_time = $this->getTimestamp();
+    }
+
+    public function stop() {
+        $this->end_time = $this->getTimestamp();
+    }
+
+    public function show() {
+        return number_format(($this->end_time) - ($this->start_time), 5);
+    }
+
+    public function stop_show() {
+        $this->end_time = $this->getTimestamp();
+
+        return number_format(($this->end_time) - ($this->start_time), 5);
+    }
+
+    public function stop_show_start() {
+        $this->end_time = $this->getTimestamp();
+        $tmp = number_format(($this->end_time) - ($this->start_time), 5);
+        $this->start_time = $this->getTimestamp();
+
+        return $tmp;
+    }
+}

--- a/website/lib/geokrety/repository/WaypointyRepository.class.php
+++ b/website/lib/geokrety/repository/WaypointyRepository.class.php
@@ -1,7 +1,9 @@
 <?php
 
-class Waypointy {
-    // database session opened with DBPConnect();
+namespace Geokrety\Repository;
+
+class WaypointyRepository {
+    // database session opened with DBConnect();
     private $dblink;
     // report current activity to stdout
     private $verbose;

--- a/website/mygeokrets.php
+++ b/website/mygeokrets.php
@@ -25,7 +25,7 @@ function mygeokrets($kret_co, $kret_userid, $limit, $title, $longin) {
             $sql = "SELECT COUNT(gk.id) FROM `gk-geokrety` AS gk WHERE gk.hands_of='$kret_userid'";
         }
 
-        $link = DBConnect();
+        $link = GKDB::getLink();
         $result = mysqli_query($link, $sql);
         list($ilosc_rzedow) = mysqli_fetch_array($result);
         mysqli_free_result($result);
@@ -119,9 +119,6 @@ function mygeokrets($kret_co, $kret_userid, $limit, $title, $longin) {
         unset($fixed_table);
     }
     ($_REQUEST['multilog'] == '1') ? $multilog = true : $multilog = false;
-
-    // speed testing
-    //include('speedtest.php'); $st=new SpeedTest; $result = mysqli_query($link, $sql); print($st->stop_show().'s'); mysqli_free_result($result);
 
     $result = mysqli_query($link, $sql);
     //$result=NULL;

--- a/website/mypage.php
+++ b/website/mypage.php
@@ -2,124 +2,125 @@
 
 require_once '__sentry.php';
 
-// smarty cache -- above this declaration should be wybierz_jezyk.php!
+try {
+    // smarty cache -- above this declaration should be wybierz_jezyk.php!
 $smarty_cache_this_page = 0; // this page should be cached for n seconds
 require_once 'smarty_start.php';
 
-$TYTUL = _('My Page');
-$OGON = '<script type="text/javascript" src="'.$config['funkcje.js'].'"></script>';     // character counters
+    $TYTUL = _('My Page');
+    $OGON = '<script type="text/javascript" src="'.$config['funkcje.js'].'"></script>';     // character counters
 
-$kret_co = $_GET['co'];
-// autopoprawione...
-$kret_userid = $_GET['userid'];
+    $kret_co = $_GET['co'];
+    // autopoprawione...
+    $kret_userid = $_GET['userid'];
 
-// jezeli anonim wchodzi na strone bez userid w url to odsylamy do zalogowania
-if ($longin_status['userid'] == null & !isset($kret_userid)) {
-    header('Location: longin.php');
-    exit;
-}
-
-if (!ctype_digit($kret_userid) & $kret_userid != null) {
-    $TRESC = "$kret_userid "._('seems to be not a valid user id.');
-} elseif ($kret_userid == '0') {
-    $TRESC = _('This user was not logged in');
-} else {
-    if ($kret_userid == null) {
-        $kret_userid = $longin_status['userid'];
-    }  // jeśli nie podano userid to wtedy bierzemy z longin_status
-
-    //include_once('whoiskret.php');
-    //include_once('whoiswho.php');
-    //include_once('waypoint_info.php');
-
-    $link = DBConnect();
-
-    if (($longin_status['userid'] != $kret_userid)) { // VIEW FOR ALL if user logged!=user being checked
-        // check user's details
-        $sql_user = "SELECT `user`, `joined`, `lang`, `lat`, `lon`, `promien`, `country` FROM `gk-users` WHERE `userid`='$kret_userid' LIMIT 1";
-    } else {   // user właściwy
-        $sql_user = "SELECT `user`, `joined`, `lang`, `lat`, `lon`, `promien`, `country`, `email`, `secid` FROM `gk-users` WHERE `userid`='$kret_userid' LIMIT 1";
-
-        $edit = '<a href="edit.php?co=email" title="Edit"><img src="'.CONFIG_CDN_IMAGES.'/icons/edit.png" alt="edit" width="16" height="16" border="0"/></a><br />'._('Password').' <a href="edit.php?co=haslo" title="Edit"><img src="'.CONFIG_CDN_IMAGES.'/icons/edit.png" alt="edit" width="16" height="16" border="0"/></a>';
-        $edit_lang = '<a href="edit.php?co=lang" title="Edit"><img src="'.CONFIG_CDN_IMAGES.'/icons/edit.png" alt="edit" width="16" height="16" border="0"/></a>';
-        $edit_statpic = '<a href="edit.php?co=statpic" title="Edit statpic"><img src="'.CONFIG_CDN_IMAGES.'/icons/edit.png" alt="edit" width="16" height="16" border="0"/> '._('Choose statpic').'</a>';
-        $edit_latlon = '<a href="edit.php?co=latlon" title="Edit"><img src="'.CONFIG_CDN_IMAGES.'/icons/edit.png" alt="edit" width="16" height="16" border="0"/></a>';
-        $dodaj_obrazek = '<a href="imgup.php?typ=2&amp;id='.$longin_status['userid'].'"><img src="'.CONFIG_CDN_IMAGES.'/icons/image.png" alt="add photo" title="add photo" width="16" height="16" border="0" /></a>';
-        $logout = '<img src="'.CONFIG_CDN_IMAGES.'/icons/exit.png" alt="logout" title="logout" width="16" height="16" /> <a href="longin.php?logout=1">'._(Logout).'</a>';
+    // jezeli anonim wchodzi na strone bez userid w url to odsylamy do zalogowania
+    if ($longin_status['userid'] == null & !isset($kret_userid)) {
+        header('Location: longin.php');
+        exit;
     }
 
-    // info o userze
-    $result = mysqli_query($link, $sql_user);
-    $row = mysqli_fetch_array($result);
-    list($user, $timestamp, $lang, $lat, $lon, $promien, $country, $email, $secid) = $row;
-    mysqli_free_result($result);
-    $TYTUL = _('My Page')." - $user";
+    if (!ctype_digit($kret_userid) & $kret_userid != null) {
+        $TRESC = "$kret_userid "._('seems to be not a valid user id.');
+    } elseif ($kret_userid == '0') {
+        $TRESC = _('This user was not logged in');
+    } else {
+        if ($kret_userid == null) {
+            $kret_userid = $longin_status['userid'];
+        }  // jeśli nie podano userid to wtedy bierzemy z longin_status
 
-    if (($longin_status['userid'] == $kret_userid)) {
-        if (empty($email)) {
-            $email = '<span style="padding-left:2em;padding-right:2em;background-color:#FF6767;">?</span>';
-            $email_warning = ' * Missing information!';
+        //include_once('whoiskret.php');
+        //include_once('whoiswho.php');
+        //include_once('waypoint_info.php');
+
+        $link = GKDB::getLink();
+
+        if (($longin_status['userid'] != $kret_userid)) { // VIEW FOR ALL if user logged!=user being checked
+            // check user's details
+            $sql_user = "SELECT `user`, `joined`, `lang`, `lat`, `lon`, `promien`, `country` FROM `gk-users` WHERE `userid`='$kret_userid' LIMIT 1";
+        } else {   // user właściwy
+            $sql_user = "SELECT `user`, `joined`, `lang`, `lat`, `lon`, `promien`, `country`, `email`, `secid` FROM `gk-users` WHERE `userid`='$kret_userid' LIMIT 1";
+
+            $edit = '<a href="edit.php?co=email" title="Edit"><img src="'.CONFIG_CDN_IMAGES.'/icons/edit.png" alt="edit" width="16" height="16" border="0"/></a><br />'._('Password').' <a href="edit.php?co=haslo" title="Edit"><img src="'.CONFIG_CDN_IMAGES.'/icons/edit.png" alt="edit" width="16" height="16" border="0"/></a>';
+            $edit_lang = '<a href="edit.php?co=lang" title="Edit"><img src="'.CONFIG_CDN_IMAGES.'/icons/edit.png" alt="edit" width="16" height="16" border="0"/></a>';
+            $edit_statpic = '<a href="edit.php?co=statpic" title="Edit statpic"><img src="'.CONFIG_CDN_IMAGES.'/icons/edit.png" alt="edit" width="16" height="16" border="0"/> '._('Choose statpic').'</a>';
+            $edit_latlon = '<a href="edit.php?co=latlon" title="Edit"><img src="'.CONFIG_CDN_IMAGES.'/icons/edit.png" alt="edit" width="16" height="16" border="0"/></a>';
+            $dodaj_obrazek = '<a href="imgup.php?typ=2&amp;id='.$longin_status['userid'].'"><img src="'.CONFIG_CDN_IMAGES.'/icons/image.png" alt="add photo" title="add photo" width="16" height="16" border="0" /></a>';
+            $logout = '<img src="'.CONFIG_CDN_IMAGES.'/icons/exit.png" alt="logout" title="logout" width="16" height="16" /> <a href="longin.php?logout=1">'._(Logout).'</a>';
         }
-        $email = "Email: $email";
 
-        $secid_pole = 'Secid: <input type="text" name="secid" value="'.$secid.'"/> ('._('keep secret!').')';
-        $secid_change_desc = _('The old secid will be deleted and the new one will be generated. You will have to update the secid in all applications which are using the code.').' '._('Are you sure?');
-        $secid_change_button_desc = _('Generate new secid');
-        $secid_pole .= " <a href='/api-secid-change.php' onClick=\"return Potwierdz(this, '".addslashes($secid_change_desc)."')\"><img src='".CONFIG_CDN_IMAGES."/icons/refresh.png' alt='regenerate' width='16' height='16' border='0' title='$secid_change_button_desc'/></a>";
-    }
+        // info o userze
+        $result = mysqli_query($link, $sql_user);
+        $row = mysqli_fetch_array($result);
+        list($user, $timestamp, $lang, $lat, $lon, $promien, $country, $email, $secid) = $row;
+        mysqli_free_result($result);
+        $TYTUL = _('My Page')." - $user";
 
-    // user's badges
+        if (($longin_status['userid'] == $kret_userid)) {
+            if (empty($email)) {
+                $email = '<span style="padding-left:2em;padding-right:2em;background-color:#FF6767;">?</span>';
+                $email_warning = ' * Missing information!';
+            }
+            $email = "Email: $email";
 
-    $sql = "SELECT `desc` , `file` FROM `gk-badges` WHERE `userid` = '$kret_userid' ORDER BY `timestamp`";
-    $result = mysqli_query($link, $sql);
-    while ($row = mysqli_fetch_array($result)) {
-        $badges .= "<img src='".CONFIG_CDN_IMAGES."/badges/$row[1]' title='$row[0]' alt='badge' /> ";
-    }
+            $secid_pole = 'Secid: <input type="text" name="secid" value="'.$secid.'"/> ('._('keep secret!').')';
+            $secid_change_desc = _('The old secid will be deleted and the new one will be generated. You will have to update the secid in all applications which are using the code.').' '._('Are you sure?');
+            $secid_change_button_desc = _('Generate new secid');
+            $secid_pole .= " <a href='/api-secid-change.php' onClick=\"return Potwierdz(this, '".addslashes($secid_change_desc)."')\"><img src='".CONFIG_CDN_IMAGES."/icons/refresh.png' alt='regenerate' width='16' height='16' border='0' title='$secid_change_button_desc'/></a>";
+        }
 
-    mysqli_free_result($result);
+        // user's badges
 
-    if ($kret_co == '1') {
-        $OGON .= '<script type="text/javascript" src="'.CONFIG_CDN_JS.'/sorttable.min.js"></script>';
-        $OGON .= '<script type="text/javascript" src="'.$config['ajaxtooltip.js'].'"></script>';
+        $sql = "SELECT `desc` , `file` FROM `gk-badges` WHERE `userid` = '$kret_userid' ORDER BY `timestamp`";
+        $result = mysqli_query($link, $sql);
+        while ($row = mysqli_fetch_array($result)) {
+            $badges .= "<img src='".CONFIG_CDN_IMAGES."/badges/$row[1]' title='$row[0]' alt='badge' /> ";
+        }
 
-        include_once 'mygeokrets.php';
-        $TRESC .= mygeokrets($kret_co, $kret_userid, 100, "$user's geokrets", $longin_status['userid']);
-    } // moje georkety
+        mysqli_free_result($result);
 
-    // ------------------------------------------------------------------- observed geokrets
+        if ($kret_co == '1') {
+            $OGON .= '<script type="text/javascript" src="'.CONFIG_CDN_JS.'/sorttable.min.js"></script>';
+            $OGON .= '<script type="text/javascript" src="'.$config['ajaxtooltip.js'].'"></script>';
 
-    elseif ($kret_co == '2') {
-        $OGON .= '<script type="text/javascript" src="'.CONFIG_CDN_JS.'/sorttable.min.js"></script>';
-        $OGON .= '<script type="text/javascript" src="'.$config['ajaxtooltip.js'].'"></script>';
+            include_once 'mygeokrets.php';
+            $TRESC .= mygeokrets($kret_co, $kret_userid, 100, "$user's geokrets", $longin_status['userid']);
+        } // moje georkety
 
-        include_once 'mygeokrets.php';
-        $TRESC .= mygeokrets($kret_co, $kret_userid, 100, "$user's watched geokrets", $longin_status['userid']);
-    } // observed geokrets
+        // ------------------------------------------------------------------- observed geokrets
 
-    // --------------------------------------------------------------------- my recent moves
+        elseif ($kret_co == '2') {
+            $OGON .= '<script type="text/javascript" src="'.CONFIG_CDN_JS.'/sorttable.min.js"></script>';
+            $OGON .= '<script type="text/javascript" src="'.$config['ajaxtooltip.js'].'"></script>';
 
-    elseif ($kret_co == '3') {
-        $OGON .= '<script type="text/javascript" src="'.CONFIG_CDN_JS.'/sorttable.min.js"></script>';
-        $OGON .= '<script type="text/javascript" src="'.$config['ajaxtooltip.js'].'"></script>';
+            include_once 'mygeokrets.php';
+            $TRESC .= mygeokrets($kret_co, $kret_userid, 100, "$user's watched geokrets", $longin_status['userid']);
+        } // observed geokrets
 
-        include_once 'recent_moves.php';
-        $TRESC .= recent_moves("WHERE ru.user='$kret_userid'", 50, _('My recent logs'), '', true, false);
-    }
+        // --------------------------------------------------------------------- my recent moves
 
-    // --------------------------------------------------------------------- recent moves of MY geokrets
+        elseif ($kret_co == '3') {
+            $OGON .= '<script type="text/javascript" src="'.CONFIG_CDN_JS.'/sorttable.min.js"></script>';
+            $OGON .= '<script type="text/javascript" src="'.$config['ajaxtooltip.js'].'"></script>';
 
-    elseif ($kret_co == '4') {
-        $OGON .= '<script type="text/javascript" src="'.CONFIG_CDN_JS.'/sorttable.min.js"></script>';
-        $OGON .= '<script type="text/javascript" src="'.$config['ajaxtooltip.js'].'"></script>';
+            include_once 'recent_moves.php';
+            $TRESC .= recent_moves("WHERE ru.user='$kret_userid'", 50, _('My recent logs'), '', true, false);
+        }
 
-        include_once 'recent_moves.php';
-        $TRESC .= recent_moves("WHERE gk.owner='$kret_userid'", 50, _('Recent moves of my geokrets'), '', true);
-    }
+        // --------------------------------------------------------------------- recent moves of MY geokrets
 
-    // ----------------------------------------- user's inventory
+        elseif ($kret_co == '4') {
+            $OGON .= '<script type="text/javascript" src="'.CONFIG_CDN_JS.'/sorttable.min.js"></script>';
+            $OGON .= '<script type="text/javascript" src="'.$config['ajaxtooltip.js'].'"></script>';
 
-    elseif ($kret_co == '5') {
-        $przetrzymywane_krety_sql = "SELECT gk.id, gk.nr, gk.nazwa, gk.opis, gk.owner, gk.data, gk.typ, us.user
+            include_once 'recent_moves.php';
+            $TRESC .= recent_moves("WHERE gk.owner='$kret_userid'", 50, _('Recent moves of my geokrets'), '', true);
+        }
+
+        // ----------------------------------------- user's inventory
+
+        elseif ($kret_co == '5') {
+            $przetrzymywane_krety_sql = "SELECT gk.id, gk.nr, gk.nazwa, gk.opis, gk.owner, gk.data, gk.typ, us.user
 							FROM `gk-geokrety` AS gk
 							LEFT JOIN `gk-ruchy` ru ON ( gk.ost_pozycja_id = ru.ruch_id )
 							LEFT JOIN `gk-users` us ON ( gk.owner = us.userid )
@@ -128,171 +129,178 @@ if (!ctype_digit($kret_userid) & $kret_userid != null) {
 								OR (gk.owner = '$kret_userid' AND gk.ost_pozycja_id = '0')
 							ORDER BY gk.id ASC";
 
-        include_once 'szukaj_kreta.php';
+            include_once 'szukaj_kreta.php';
 
-        //$TRESC .= szukaj_kreta("", 100, _("Geokrets in my inventory"), $longin_status['userid'], $przetrzymywane_krety_sql);
+            //$TRESC .= szukaj_kreta("", 100, _("Geokrets in my inventory"), $longin_status['userid'], $przetrzymywane_krety_sql);
 
-        $OGON .= '<script type="text/javascript" src="'.CONFIG_CDN_JS.'/sorttable.min.js"></script>';
-        $OGON .= '<script type="text/javascript" src="'.$config['ajaxtooltip.js'].'"></script>';
+            $OGON .= '<script type="text/javascript" src="'.CONFIG_CDN_JS.'/sorttable.min.js"></script>';
+            $OGON .= '<script type="text/javascript" src="'.$config['ajaxtooltip.js'].'"></script>';
 
-        include_once 'mygeokrets.php';
-        $TYTUL = sprintf(_("%s's Inventory"), $user);
-        $TRESC .= mygeokrets($kret_co, $kret_userid, 100, $TYTUL, $longin_status['userid']);
-    } elseif ($kret_co == '6') {
-    } else {    // --------------------------------------------------------------------- user's info
-        if ($lat != null and $lon != null) {
-            if ($lat != 0) {
-                $lat = (abs($lat) / $lat) * floor(abs($lat)).'° '.round(60 * (abs($lat) - floor(abs($lat))), 4);
-            }
-            if ($lon != 0) {
-                $lon = (abs($lon) / $lon) * floor(abs($lon)).'° '.round(60 * (abs($lon) - floor(abs($lon))), 4);
-            }
-        } else {
-            $lat = '?';
-            $lon = '?';
-        } //gdy nieustawione
+            include_once 'mygeokrets.php';
+            $TYTUL = sprintf(_("%s's Inventory"), $user);
+            $TRESC .= mygeokrets($kret_co, $kret_userid, 100, $TYTUL, $longin_status['userid']);
+        } elseif ($kret_co == '6') {
+        } else {    // --------------------------------------------------------------------- user's info
+            if ($lat != null and $lon != null) {
+                if ($lat != 0) {
+                    $lat = (abs($lat) / $lat) * floor(abs($lat)).'° '.round(60 * (abs($lat) - floor(abs($lat))), 4);
+                }
+                if ($lon != 0) {
+                    $lon = (abs($lon) / $lon) * floor(abs($lon)).'° '.round(60 * (abs($lon) - floor(abs($lon))), 4);
+                }
+            } else {
+                $lat = '?';
+                $lon = '?';
+            } //gdy nieustawione
 
-        if (($longin_status['userid'] == $kret_userid)) {
-            $coords = _('Home coordinates').' &amp; '.strtolower(_('Observation area')).' '.$edit_latlon;
-        }
-
-        // ---------------------------------------------- statystyki geokretów/usera, medale itp -------------------------------------------- //
-
-        // odznaczenia - co i za ile :) --- //
-
-        function jakie_odznaczenie_przyznac($geokretow_w_puli) {
-            if ($geokretow_w_puli >= 1) {
-                $odznaczenia_pliki['1'] = 'medal-1-1.png';
-            }
-            if ($geokretow_w_puli >= 10) {
-                $odznaczenia_pliki['10'] = 'medal-1-2.png';
-            }
-            if ($geokretow_w_puli >= 20) {
-                $odznaczenia_pliki['20'] = 'medal-1-3.png';
-            }
-            if ($geokretow_w_puli >= 50) {
-                $odznaczenia_pliki['50'] = 'medal-1-4.png';
-            }
-            if ($geokretow_w_puli >= 100) {
-                $odznaczenia_pliki['100'] = 'medal-bialy.png';
-            }
-            if ($geokretow_w_puli >= 120) {
-                $odznaczenia_pliki['5! = 120'] = 'medal-120.png';
-            }
-            if ($geokretow_w_puli >= 200) {
-                $odznaczenia_pliki['200'] = 'medal-brazowy.png';
-            }
-            if ($geokretow_w_puli >= 314) {
-                $odznaczenia_pliki['100* Pi = 100 * 3.14 = 314'] = 'medal-pi.png';
-            }
-            if ($geokretow_w_puli >= 500) {
-                $odznaczenia_pliki['500'] = 'medal-srebrny.png';
-            }
-            if ($geokretow_w_puli >= 512) {
-                $odznaczenia_pliki['2^9 = 512'] = 'medal-512.png';
-            }
-            if ($geokretow_w_puli >= 720) {
-                $odznaczenia_pliki['6! = 1*2*3*4*5*6 = 720'] = 'medal-720.png';
-            }
-            if ($geokretow_w_puli >= 800) {
-                $odznaczenia_pliki['800'] = 'medal-zloty.png';
-            }
-            if ($geokretow_w_puli >= 1000) {
-                $odznaczenia_pliki['1000'] = 'medal-1000.png';
-            }
-            if ($geokretow_w_puli >= 1024) {
-                $odznaczenia_pliki['2^10 = 1024'] = 'medal-1024.png';
-            }
-            if ($geokretow_w_puli >= 2000) {
-                $odznaczenia_pliki['2000'] = 'medal-2000.png';
-            }
-            if ($geokretow_w_puli >= 3000) {
-                $odznaczenia_pliki['3000'] = 'medal-3000.png';
-            }
-            if ($geokretow_w_puli >= 5000) {
-                $odznaczenia_pliki['5000'] = 'medal-5000.png';
-            }
-            if ($geokretow_w_puli >= 5040) {
-                $odznaczenia_pliki['7! = 1*2*3*4*5*6*7 = 5040'] = 'medal-5040.png';
-            }
-            if ($geokretow_w_puli >= 10000) {
-                $odznaczenia_pliki['10000'] = 'medal-10000.png';
+            if (($longin_status['userid'] == $kret_userid)) {
+                $coords = _('Home coordinates').' &amp; '.strtolower(_('Observation area')).' '.$edit_latlon;
             }
 
-            return $odznaczenia_pliki;
-        }
+            // --------------------stats geokrets and users medals --- //
+            // decorations - what and for how much //
 
-        // --------------------------------- SWOJE
-        $result = mysqli_query($link, "SELECT COUNT(`id`), COALESCE(SUM(droga),0) FROM `gk-geokrety` WHERE owner='$kret_userid' AND `typ` != '2' LIMIT 1");
-        list($geokretow_w_puli, $droga_geokretow_usera) = mysqli_fetch_array($result);
+            /**
+             * Determine granted awards given geokrety count.
+             *
+             * @return awards array of indexed values
+             *                index key: award title suffix
+             *                value: award image names
+             */
+            function determineGrantedAwards($geokretow_w_puli) {
+                if ($geokretow_w_puli >= 1) {
+                    $odznaczenia_pliki['1'] = 'medal-1-1.png';
+                }
+                if ($geokretow_w_puli >= 10) {
+                    $odznaczenia_pliki['10'] = 'medal-1-2.png';
+                }
+                if ($geokretow_w_puli >= 20) {
+                    $odznaczenia_pliki['20'] = 'medal-1-3.png';
+                }
+                if ($geokretow_w_puli >= 50) {
+                    $odznaczenia_pliki['50'] = 'medal-1-4.png';
+                }
+                if ($geokretow_w_puli >= 100) {
+                    $odznaczenia_pliki['100'] = 'medal-bialy.png';
+                }
+                if ($geokretow_w_puli >= 120) {
+                    $odznaczenia_pliki['5! = 120'] = 'medal-120.png';
+                }
+                if ($geokretow_w_puli >= 200) {
+                    $odznaczenia_pliki['200'] = 'medal-brazowy.png';
+                }
+                if ($geokretow_w_puli >= 314) {
+                    $odznaczenia_pliki['100* Pi = 100 * 3.14 = 314'] = 'medal-pi.png';
+                }
+                if ($geokretow_w_puli >= 500) {
+                    $odznaczenia_pliki['500'] = 'medal-srebrny.png';
+                }
+                if ($geokretow_w_puli >= 512) {
+                    $odznaczenia_pliki['2^9 = 512'] = 'medal-512.png';
+                }
+                if ($geokretow_w_puli >= 720) {
+                    $odznaczenia_pliki['6! = 1*2*3*4*5*6 = 720'] = 'medal-720.png';
+                }
+                if ($geokretow_w_puli >= 800) {
+                    $odznaczenia_pliki['800'] = 'medal-zloty.png';
+                }
+                if ($geokretow_w_puli >= 1000) {
+                    $odznaczenia_pliki['1000'] = 'medal-1000.png';
+                }
+                if ($geokretow_w_puli >= 1024) {
+                    $odznaczenia_pliki['2^10 = 1024'] = 'medal-1024.png';
+                }
+                if ($geokretow_w_puli >= 2000) {
+                    $odznaczenia_pliki['2000'] = 'medal-2000.png';
+                }
+                if ($geokretow_w_puli >= 3000) {
+                    $odznaczenia_pliki['3000'] = 'medal-3000.png';
+                }
+                if ($geokretow_w_puli >= 5000) {
+                    $odznaczenia_pliki['5000'] = 'medal-5000.png';
+                }
+                if ($geokretow_w_puli >= 5040) {
+                    $odznaczenia_pliki['7! = 1*2*3*4*5*6*7 = 5040'] = 'medal-5040.png';
+                }
+                if ($geokretow_w_puli >= 10000) {
+                    $odznaczenia_pliki['10000'] = 'medal-10000.png';
+                }
 
-        $statystyki_usera = sprintf(_('%s has created <b>%s</b> GeoKrets, which travelled <b>%s</b> km.'), $user, $geokretow_w_puli, $droga_geokretow_usera);
-
-        if ($geokretow_w_puli > 0) {
-            $odznaczenia_pliki = jakie_odznaczenie_przyznac($geokretow_w_puli);
-
-            foreach ($odznaczenia_pliki as $key => $odznaczenie_plik) {
-                $lista_odznaczen_geokrety_usera .= '<img src="'.CONFIG_CDN_IMAGES.'/medals/'.$odznaczenie_plik.'" alt="award for '.$key.' geokrets" title="award for '.$key.' geokrets" /> ';
+                return $odznaczenia_pliki;
             }
-            unset($odznaczenia_pliki);
-        }
 
-        // --------------------------------- OBCE (i swoje też)
-        $result = mysqli_query($link,
-            "SELECT COUNT(`ruch_id`), COALESCE(SUM(droga),0) FROM `gk-ruchy` WHERE (`logtype` = '0' OR `logtype` = '5') AND `user` = '$kret_userid' AND `gk-ruchy`.`id`
+            // --------------------------------- SWOJE
+            $result = mysqli_query($link, "SELECT COUNT(`id`), COALESCE(SUM(droga),0) FROM `gk-geokrety` WHERE owner='$kret_userid' AND `typ` != '2' LIMIT 1");
+            list($geokretow_w_puli, $droga_geokretow_usera) = mysqli_fetch_array($result);
+
+            $statystyki_usera = sprintf(_('%s has created <b>%s</b> GeoKrets, which travelled <b>%s</b> km.'), $user, $geokretow_w_puli, $droga_geokretow_usera);
+
+            if ($geokretow_w_puli > 0) {
+                $odznaczenia_pliki = determineGrantedAwards($geokretow_w_puli);
+
+                foreach ($odznaczenia_pliki as $key => $odznaczenie_plik) {
+                    $lista_odznaczen_geokrety_usera .= '<img src="'.CONFIG_CDN_IMAGES.'/medals/'.$odznaczenie_plik.'" alt="award for '.$key.' geokrets" title="award for '.$key.' geokrets" /> ';
+                }
+                unset($odznaczenia_pliki);
+            }
+
+            // --------------------------------- OBCE (i swoje też)
+            $result = mysqli_query(
+              $link,
+              "SELECT COUNT(`ruch_id`), COALESCE(SUM(droga),0) FROM `gk-ruchy` WHERE (`logtype` = '0' OR `logtype` = '5') AND `user` = '$kret_userid' AND `gk-ruchy`.`id`
 	IN (
 	SELECT `id`
 	FROM `gk-geokrety`
 	WHERE `typ` != '2'
 	) LIMIT 1"
-        );
-        list($geokretow_w_puli, $droga_geokretow_obcych) = mysqli_fetch_array($result);
+            );
+            list($geokretow_w_puli, $droga_geokretow_obcych) = mysqli_fetch_array($result);
 
-        $statystyki_obce = sprintf(_('%s has moved <b>%s</b> GeoKrets on a total distance of <b>%s</b> km.'), $user, $geokretow_w_puli, $droga_geokretow_obcych);
+            $statystyki_obce = sprintf(_('%s has moved <b>%s</b> GeoKrets on a total distance of <b>%s</b> km.'), $user, $geokretow_w_puli, $droga_geokretow_obcych);
 
-        // odznaczenia ---- //
+            // odznaczenia ---- //
 
-        if ($geokretow_w_puli > 0) {
-            $odznaczenia_pliki = jakie_odznaczenie_przyznac($geokretow_w_puli);
+            if ($geokretow_w_puli > 0) {
+                $odznaczenia_pliki = determineGrantedAwards($geokretow_w_puli);
 
-            foreach ($odznaczenia_pliki as $key => $odznaczenie_plik) {
-                $lista_odznaczen_geokrety_obce .= '<img src="'.CONFIG_CDN_IMAGES.'/medals/'.$odznaczenie_plik.'" alt="award for '.$key.' geokrets" title="award for '.$key.' geokrets" /> ';
+                foreach ($odznaczenia_pliki as $key => $odznaczenie_plik) {
+                    $lista_odznaczen_geokrety_obce .= '<img src="'.CONFIG_CDN_IMAGES.'/medals/'.$odznaczenie_plik.'" alt="award for '.$key.' geokrets" title="award for '.$key.' geokrets" /> ';
+                }
+                unset($odznaczenia_pliki);
             }
-            unset($odznaczenia_pliki);
-        }
 
-        // ---------------------------------------------- statystyki geokretów/usera, medale itp -------------------------------------------- //
+            // ---------------------------------------------- statystyki geokretów/usera, medale itp --- //
 
-        // ----------- JEŚLI USER ZALOGOWANY --------//
-        if (($longin_status['userid'] != 0)) {
-            //$result = mysqli_query($link, "SELECT `user` FROM `gk-users` WHERE `userid`='$kret_userid' AND `email` != '' LIMIT 1");
-            //$row = mysqli_fetch_row($result); mysqli_free_result($result);
+            // ----------- JEŚLI USER ZALOGOWANY --------//
+            if (($longin_status['userid'] != 0)) {
+                //$result = mysqli_query($link, "SELECT `user` FROM `gk-users` WHERE `userid`='$kret_userid' AND `email` != '' LIMIT 1");
+                //$row = mysqli_fetch_row($result); mysqli_free_result($result);
 
-            // jeśli email user chce dostawać
-            //if($row[0]!='')
-            $wyslij_wiadomosc = '<img src="'.CONFIG_CDN_IMAGES.'/icons/email.png" alt="send message to user" title="send message to user" width="16" height="16" /> <a href="majluj.php?to='.$kret_userid.'">'._('Send a message to the user').'</a>.';
-        }
-
-        // ------------------------------------------------------------------- my geokrets
-
-        //-------------------------------------------- OBRAZKI ------------------------------- //
-        $result = mysqli_query($link, "SELECT `obrazekid`, `plik`, `opis` FROM `gk-obrazki` WHERE `id`='".$kret_userid."' AND (`typ`='2') ORDER BY `timestamp` ASC LIMIT 8");
-
-        while ($row = mysqli_fetch_row($result)) {
-            list($obrazki_id, $obrazki_plik, $obrazki_opis) = $row;
-
-            $OBRAZKI .= "<span class=\"obrazek\"><a href=\"obrazki/$obrazki_plik\" target=\"_blank\"><img src=\"".CONFIG_CDN_OBRAZKI_MALE."/$obrazki_plik\" border=\"0\" alt=\"$obrazki_opis\" title=\"$obrazki_opis\" width=\"100\" height=\"100\"/></a><br />$obrazki_opis";
-
-            if ($longin_status['userid'] == $kret_userid) {
-                $OBRAZKI .= ' <a href="edit.php?delete_obrazek='.$obrazki_id.'" onClick="return CzySkasowac(this, \'this entry???\')"><img src="'.CONFIG_CDN_IMAGES.'/icons/delete.png" alt="delete" width="11" height="11" border="0" /></a>';
+                // jeśli email user chce dostawać
+                //if($row[0]!='')
+                $wyslij_wiadomosc = '<img src="'.CONFIG_CDN_IMAGES.'/icons/email.png" alt="send message to user" title="send message to user" width="16" height="16" /> <a href="majluj.php?to='.$kret_userid.'">'._('Send a message to the user').'</a>.';
             }
-            $OBRAZKI .= '</span>';
 
-            $OBRAZKI = '<div id="obrazek_box">'.$OBRAZKI.'</div>';
-        }
-        //-------------------------------------------- OBRAZKI: end ------------------------------- //
+            // ------------------------------------------------------------------- my geokrets
 
-        $TRESC = '
+            //-------------------------------------------- OBRAZKI ------------------------------- //
+            $result = mysqli_query($link, "SELECT `obrazekid`, `plik`, `opis` FROM `gk-obrazki` WHERE `id`='".$kret_userid."' AND (`typ`='2') ORDER BY `timestamp` ASC LIMIT 8");
+
+            while ($row = mysqli_fetch_row($result)) {
+                list($obrazki_id, $obrazki_plik, $obrazki_opis) = $row;
+
+                $OBRAZKI .= "<span class=\"obrazek\"><a href=\"obrazki/$obrazki_plik\" target=\"_blank\"><img src=\"".CONFIG_CDN_OBRAZKI_MALE."/$obrazki_plik\" border=\"0\" alt=\"$obrazki_opis\" title=\"$obrazki_opis\" width=\"100\" height=\"100\"/></a><br />$obrazki_opis";
+
+                if ($longin_status['userid'] == $kret_userid) {
+                    $OBRAZKI .= ' <a href="edit.php?delete_obrazek='.$obrazki_id.'" onClick="return CzySkasowac(this, \'this entry???\')"><img src="'.CONFIG_CDN_IMAGES.'/icons/delete.png" alt="delete" width="11" height="11" border="0" /></a>';
+                }
+                $OBRAZKI .= '</span>';
+
+                $OBRAZKI = '<div id="obrazek_box">'.$OBRAZKI.'</div>';
+            }
+            //-------------------------------------------- OBRAZKI: end ------------------------------- //
+
+            $TRESC = '
 <table width="100%" style="padding-top: 1px;">
 
 <!-- ---------------------------- USER ----------------------------------------------- -->
@@ -322,26 +330,33 @@ if (!ctype_digit($kret_userid) & $kret_userid != null) {
 <tr><td class="tresc1">'.$wyslij_wiadomosc.'</td></tr>
 </table>
 
-<!-- ---------------------------- stats and awards ----------------------------------------------- -->
+<!-- ---------------------------- stats and awards ------------- -->
 <table width="100%" style="padding-top: 22px;">
-<tr><td class="heading1"><img src="'.CONFIG_CDN_IMAGES.'/icons/stat.png" alt="tools" width="16" height="16" /> '._('Statistics').'</td></tr>
+<tr><td class="heading1">
+  <img src="'.CONFIG_CDN_IMAGES.'/icons/stat.png" alt="tools" width="16" height="16" /> '._('Statistics').'
+</td></tr>
 
 <tr><td class="tresc1">'.$statystyki_usera.'</td></tr>
 <tr><td class="tresc1">'.$lista_odznaczen_geokrety_usera.'</td></tr>
 
 <tr><td class="tresc1">'.$statystyki_obce.'</td></tr>
 <tr><td class="tresc1">'.$lista_odznaczen_geokrety_obce.'</td></tr>
-<tr><td class="tresc1" style="text-align: right;"><img src="'.CONFIG_CDN_IMAGES.'/icons/stat.png" width="16" height="16" alt="stats" /> <a href="user_stat.php?userid='.$kret_userid.'">'._('User stats').'</a></td></tr>
+<tr><td class="tresc1" style="text-align: right;">
+  <img src="'.CONFIG_CDN_IMAGES.'/icons/stat.png" width="16" height="16" alt="stats" />
+   <a href="user_stat.php?userid='.$kret_userid.'">'._('User stats').'</a>
+</td></tr>
 </table>
 
-<!-- ---------------------------- badges ----------------------------------------------- -->
+<!-- ---------------------------- badges ------------------------- -->
 <table width="100%" style="padding-top: 22px;">
-<tr><td class="heading1"><img src="'.CONFIG_CDN_IMAGES.'/icons/stat.png" alt="tools" width="16" height="16" /> '._('Badges').'</td></tr>
+<tr><td class="heading1">
+  <img src="'.CONFIG_CDN_IMAGES.'/icons/stat.png" alt="tools" width="16" height="16" /> '._('Badges').'
+</td></tr>
 <tr><td class="tresc1">'.$badges.'</td></tr>
 </table>
 
 
-<!-- ----------------------------  banner / signature ----------------------------------------------- -->
+<!-- ----------------------------  banner / signature ------------- -->
 <table width="100%" style="padding-top: 22px;">
 <tr><td class="heading1"><img src="'.CONFIG_CDN_IMAGES.'/icons/sign.png" alt="tools" width="22" height="22" /></td></tr>
 
@@ -357,7 +372,7 @@ BB Code:  <span class="szare">[url='.$config['adres'].'mypage.php?userid='.$kret
 </tr>
 </table>
 
-<!-- ---------------------------- links ----------------------------------------------- -->
+<!-- ---------------------------- links --------------------- -->
 <table width="100%" style="padding-top: 22px;">
 <tr><td class="heading1"><img src="'.CONFIG_CDN_IMAGES.'/icons/tool.png" alt="tools" width="22" height="22" /> '._('Links').'</td></tr>
 <tr>
@@ -377,12 +392,15 @@ BB Code:  <span class="szare">[url='.$config['adres'].'mypage.php?userid='.$kret
 
 
 </table>';
-    } //difoltowo - user info
-}
-// --------------------------------------------------------------- SMARTY ---------------------------------------- //
+        } //difoltowo - user info
+    }
+    // ------------------------------ SMARTY ------------------------------ //
 
-if (isset($link)) {
-    mysqli_close($link);
+    if (isset($link)) {
+        mysqli_close($link);
+    }
+    $link = null; // prevent warning at smarty.php
+    require_once 'smarty.php';
+} catch (Exception $exc) {
+    echo 'Service unavailable - '.$exc->getMessage();
 }
-$link = null; // prevent warning at smarty.php
-require_once 'smarty.php';

--- a/website/poprawki.php
+++ b/website/poprawki.php
@@ -199,7 +199,6 @@ if ($y) {
     if ($ok == true) {
         unset($result);
         if ($sql0 != '') {
-            include_once 'speedtest.php';
             $st = new SpeedTest();
             $TRESC .= "SQL: $sql0";
             $result = mysqli_query($link, $sql0);
@@ -242,7 +241,6 @@ if ($y) {
     if ($ok == true) {
         unset($result);
         if ($sql != '' && !isset($g_readonly)) {
-            include_once 'speedtest.php';
             $st = new SpeedTest();
             $TRESC .= "SQL: $sql<br />";
             $result = mysqli_query($link, $sql);

--- a/website/recent_moves.php
+++ b/website/recent_moves.php
@@ -22,7 +22,7 @@ function recent_moves($where, $limit, $title = '', $zapytanie = '', $showheaders
         $prefix_adresu = '';
     }
 
-    $link = DBConnect();
+    $link = GKDB::getLink();
 
     $po_ile = 0;
 
@@ -71,6 +71,12 @@ function recent_moves($where, $limit, $title = '', $zapytanie = '', $showheaders
     } // if zapytanie==''
 
     unset($table_layout, $fixed_table, $table_headers);
+    $fixed_table[1] = '';
+    $fixed_table[2] = '';
+    $fixed_table[3] = '';
+    $fixed_table[4] = '';
+    $fixed_table[5] = '';
+    $fixed_table[6] = '';
     $sortable = '';
     if ($showheaders or $emailversion) {
         if ($po_ile > 50) { // w tej chwili nie uzywane bo wylaczona jest opcja show_all

--- a/website/recentlogs.php
+++ b/website/recentlogs.php
@@ -2,23 +2,27 @@
 
 require_once '__sentry.php';
 
-// smarty cache -- above this declaration should be wybierz_jezyk.php!
+try {
+    // smarty cache -- above this declaration should be wybierz_jezyk.php!
 $smarty_cache_this_page = 0; // this page should be cached for n seconds
 require_once 'smarty_start.php';
 
-$TYTUL = _('Recent logs');
+    $TYTUL = _('Recent logs');
 
-$link = DBConnect();
+    $link = GKDB::getLink();
 
-// -------------------------------------- recent moves ------------------------------- //
+    // -------------------------------------- recent moves ------------------------------- //
 
-require_once 'recent_moves.php';
+    require_once 'recent_moves.php';
 
     $OGON .= '<script type="text/javascript" src="sorttable-1.min.js"></script>';
     $OGON .= '<script type="text/javascript" src="'.$config['ajaxtooltip.js'].'"></script>';
 
     $TRESC .= recent_moves('', 50, '', '', true);
 
-// --------------------------------------------------------------- SMARTY ---------------------------------------- //
+    // --------------------------------------------------------------- SMARTY ---------------------------------------- //
 
-require_once 'smarty.php';
+    require_once 'smarty.php';
+} catch (Exception $exc) {
+    echo 'Service unavailable - '.$exc->getMessage();
+}

--- a/website/ruchy.php
+++ b/website/ruchy.php
@@ -60,7 +60,7 @@ $user = $longin_status['userid'];
 
 // preg_replace("/[^a-z0-9.:]+/i", "", $string);
 
-$link = DBConnect();
+$link = GKDB::getLink();
 
 // if mobile version is set
 if ($longin_status['mobile_mode'] == 1) {

--- a/website/speedtest.php
+++ b/website/speedtest.php
@@ -1,53 +1,8 @@
 <?php
 
-// script execution time test
+ // deprecated:
+ //  - already imported with wendor/autoload.php
+ //  - remove "include_once 'speedtest.php';"
 
-/*
-include('speedtest.php');
-$st=new SpeedTest;
-...
-echo $st->stop_show();
-*/
-
-class speedtest {
-    private $start_time;
-    private $end_time;
-
-    public function SpeedTest() {
-        $this->end_time = 0;
-        $this->start_time = $this->getTimestamp();
-    }
-
-    private function getTimestamp() {
-        $now = gettimeofday();
-
-        return $now['sec'] + ($now['usec'] / 1000000);
-    }
-
-    public function start() //called automatically at creation as well
-    {
-        $this->start_time = $this->getTimestamp();
-    }
-
-    public function stop() {
-        $this->end_time = $this->getTimestamp();
-    }
-
-    public function show() {
-        return number_format(($this->end_time) - ($this->start_time), 5);
-    }
-
-    public function stop_show() {
-        $this->end_time = $this->getTimestamp();
-
-        return number_format(($this->end_time) - ($this->start_time), 5);
-    }
-
-    public function stop_show_start() {
-        $this->end_time = $this->getTimestamp();
-        $tmp = number_format(($this->end_time) - ($this->start_time), 5);
-        $this->start_time = $this->getTimestamp();
-
-        return $tmp;
-    }
-}
+ // always used by some geokrety-scripts
+ require_once 'lib/SpeedTest.php';

--- a/website/szukaj-ajax.php
+++ b/website/szukaj-ajax.php
@@ -2,9 +2,19 @@
 
 require_once '__sentry.php';
 
-// śćńółżź
+function unexpectedError($message) {
+    try {
+        $return['tresc'] = '<img src="'.CONFIG_CDN_IMAGES.'/icons/error.png" alt="error" id="szukaj_img_error_unexpected" width="16" height="16" /> '.$message;
+        echo json_encode($return);
+    } catch (Exception $jExc) {
+        echo $message;
+    }
+}
 
-// MySQL
+try {
+    // śćńółżź
+
+    // MySQL
 require_once 'wybierz_jezyk.php'; // choose the user's language
 require 'templates/konfig.php';    // config
 
@@ -16,215 +26,216 @@ function waypointLinkLabel($waypoint, $name) {
     return sprintf(_('waypoint %s'), strtoupper($waypoint));
 }
 
-/**
- * json result (tresc) to send when ONE cache is selected.
- */
-function cacheOk($waypoint, $cache_link, $name, $owner, $cache_type, $cache_country, $countryCode) {
-    $flagPlaceholder = '';
-    if (trim($countryCode) !== '') {
-        $flagPlaceholder = '<img src="'.CONFIG_CDN_IMAGES.'/country-codes/'.$countryCode.'.png" width="16" height="11"'
+    /**
+     * json result (tresc) to send when ONE cache is selected.
+     */
+    function cacheOk($waypoint, $cache_link, $name, $owner, $cache_type, $cache_country, $countryCode) {
+        $flagPlaceholder = '';
+        if (trim($countryCode) !== '') {
+            $flagPlaceholder = '<img src="'.CONFIG_CDN_IMAGES.'/country-codes/'.$countryCode.'.png" width="16" height="11"'
                          .' alt="'._('flag').'" title="'.$countryCode.'"/>';
-    }
-    if (trim($owner) !== '') {
-        $ownerPlaceholder = '('.sprintf(_('by %s'), $owner).')';
-    }
-
-    $result = '<img src="'.CONFIG_CDN_IMAGES.'/icons/ok.png" alt="'._('OK').'" id="szukaj_img_ok" width="16" height="16" /> <a href="'.$cache_link.'" target="_opencaching">'.waypointLinkLabel($waypoint, $name).' <i class="glyphicon glyphicon-link"></i></a> '.$ownerPlaceholder.'<br />';
-    if (trim($cache_type) !== '') {
-        $result .= sprintf(_('cache type: %s'), _($cache_type)).'<br/>';
-    }
-    if (trim($cache_country) !== '') {
-        $result .= sprintf(_('country: %s %s'), $flagPlaceholder, _($cache_country));
-    } elseif (trim($countryCode) !== '') {
-        $result .= sprintf(_('country: %s'), $flagPlaceholder);
-    }
-
-    return $result;
-}
-
-/**
- * json result (tresc) to send when NO cache found.
- */
-function noCacheFound() {
-    return '<img src="'.CONFIG_CDN_IMAGES.'/icons/error.png" alt="error" id="szukaj_img_error_no_cache" width="16" height="16" /> '._('No cache found');
-}
-/**
- * json result (tresc) to send when cache code is unknown.
- */
-function cacheUnknown() {
-    return '<img src="'.CONFIG_CDN_IMAGES.'/icons/error.png" alt="error" id="szukaj_img_error_missing" width="16" height="16" /> '._('Missing or invalid coordinates');
-}
-
-/**
- * json result (tresc) to send when selected cache is not associated with lat/lon.
- */
-function cacheWithoutLatLon($waypoint, $name, $cache_link) {
-    $link_wpt = '<a href="'.$cache_link.'" target="_opencaching">'.waypointLinkLabel($waypoint, $name).' <i class="glyphicon glyphicon-link"></i></a>';
-
-    return '<img src="'.CONFIG_CDN_IMAGES.'/icons/info3.png" alt="info" id="szukaj_img_info_provide" width="16" height="16" /> '.sprintf(_('Please provide the coordinates (lat/lon) of the cache %s in the "coordinates" input box.'), $link_wpt).'<br />'.
-        sprintf(_('<a href="%s">Learn more about hiding geokrets in GC caches</a>'), $config['adres'].'help.php#locationdlagc');
-}
-
-function handleExeption($exc) {
-    $errorId = uniqid('GKIE_');
-    error_log('Unexpected error '.$errorId.' :'.$exc->getMessage());
-    error_log($exc);
-
-    return '<img src="'.CONFIG_CDN_IMAGES.'/icons/error.png" alt="error" id="szukaj_img_error_unexpected" width="16" height="16" /> '.sprintf(_('Unexpected error (id:%s), please report.'), $errorId);
-}
-
-if ($_REQUEST['skad'] == 'ajax') {
-    $link = DBConnect();
-
-    // język
-
-    $lang = $_COOKIE['geokret1'];
-    //setlocale(LC_MESSAGES , $lang);
-    //setlocale(LC_NUMERIC , 'en_EN');
-    bindtextdomain('messages', BINDTEXTDOMAIN_PATH);
-    bind_textdomain_codeset('messages', 'UTF-8');
-    textdomain('messages');
-
-    if (!empty($_REQUEST['nr'])) { // **************************************** geokret
-        $where = '';
-        $nr = $_REQUEST['nr'];
-
-        if (preg_match('/^[a-zA-Z0-9]{6}$/', $nr)) {
-            $where = "WHERE gk.nr = '$nr' LIMIT 1";
-        } else {
-            if (preg_match("/^[a-zA-Z0-9]{6}(\.[a-zA-Z0-9]{6})*$/", $nr)) {
-                $nr = str_replace('.', "','", $nr);
-                $where = "WHERE gk.nr IN ('$nr')";
-            }
+        }
+        if (trim($owner) !== '') {
+            $ownerPlaceholder = '('.sprintf(_('by %s'), $owner).')';
         }
 
-        if ($where != '') {
-            $sql = "SELECT gk.id, gk.typ, gk.nazwa, us.userid, us.user, ru.data, ru.waypoint, ru.logtype, wpt.name, ru.lat, ru.lon
+        $result = '<img src="'.CONFIG_CDN_IMAGES.'/icons/ok.png" alt="'._('OK').'" id="szukaj_img_ok" width="16" height="16" /> <a href="'.$cache_link.'" target="_opencaching">'.waypointLinkLabel($waypoint, $name).' <i class="glyphicon glyphicon-link"></i></a> '.$ownerPlaceholder.'<br />';
+        if (trim($cache_type) !== '') {
+            $result .= sprintf(_('cache type: %s'), _($cache_type)).'<br/>';
+        }
+        if (trim($cache_country) !== '') {
+            $result .= sprintf(_('country: %s %s'), $flagPlaceholder, _($cache_country));
+        } elseif (trim($countryCode) !== '') {
+            $result .= sprintf(_('country: %s'), $flagPlaceholder);
+        }
+
+        return $result;
+    }
+
+    /**
+     * json result (tresc) to send when NO cache found.
+     */
+    function noCacheFound() {
+        return '<img src="'.CONFIG_CDN_IMAGES.'/icons/error.png" alt="error" id="szukaj_img_error_no_cache" width="16" height="16" /> '._('No cache found');
+    }
+    /**
+     * json result (tresc) to send when cache code is unknown.
+     */
+    function cacheUnknown() {
+        return '<img src="'.CONFIG_CDN_IMAGES.'/icons/error.png" alt="error" id="szukaj_img_error_missing" width="16" height="16" /> '._('Missing or invalid coordinates');
+    }
+
+    /**
+     * json result (tresc) to send when selected cache is not associated with lat/lon.
+     */
+    function cacheWithoutLatLon($waypoint, $name, $cache_link) {
+        $link_wpt = '<a href="'.$cache_link.'" target="_opencaching">'.waypointLinkLabel($waypoint, $name).' <i class="glyphicon glyphicon-link"></i></a>';
+
+        return '<img src="'.CONFIG_CDN_IMAGES.'/icons/info3.png" alt="info" id="szukaj_img_info_provide" width="16" height="16" /> '.sprintf(_('Please provide the coordinates (lat/lon) of the cache %s in the "coordinates" input box.'), $link_wpt).'<br />'.
+        sprintf(_('<a href="%s">Learn more about hiding geokrets in GC caches</a>'), $config['adres'].'help.php#locationdlagc');
+    }
+
+    function handleException($exc) {
+        $errorId = uniqid('GKIE_');
+        $errorMessage = 'Unexpected error '.$errorId.' :'.$exc->getMessage();
+        error_log($errorMessage);
+        error_log($exc);
+        unexpectedError($errorMessage);
+    }
+
+    if ($_REQUEST['skad'] == 'ajax') {
+        $link = GKDB::getLink();
+
+        // język
+
+        $lang = $_COOKIE['geokret1'];
+        //setlocale(LC_MESSAGES , $lang);
+        //setlocale(LC_NUMERIC , 'en_EN');
+        bindtextdomain('messages', BINDTEXTDOMAIN_PATH);
+        bind_textdomain_codeset('messages', 'UTF-8');
+        textdomain('messages');
+
+        if (!empty($_REQUEST['nr'])) { // **************************************** geokret
+            $where = '';
+            $nr = $_REQUEST['nr'];
+
+            if (preg_match('/^[a-zA-Z0-9]{6}$/', $nr)) {
+                $where = "WHERE gk.nr = '$nr' LIMIT 1";
+            } else {
+                if (preg_match("/^[a-zA-Z0-9]{6}(\.[a-zA-Z0-9]{6})*$/", $nr)) {
+                    $nr = str_replace('.', "','", $nr);
+                    $where = "WHERE gk.nr IN ('$nr')";
+                }
+            }
+
+            if ($where != '') {
+                $sql = "SELECT gk.id, gk.typ, gk.nazwa, us.userid, us.user, ru.data, ru.waypoint, ru.logtype, wpt.name, ru.lat, ru.lon
 					FROM `gk-geokrety` gk
 					LEFT JOIN `gk-users` us ON us.userid = gk.owner
 					LEFT JOIN `gk-ruchy` ru ON ru.ruch_id=gk.ost_pozycja_id
 					LEFT JOIN `gk-waypointy` wpt ON wpt.waypoint = ru.waypoint
 					$where";
-            $result = mysqli_query($link, $sql);
-            $ret = '';
+                $result = mysqli_query($link, $sql);
+                $ret = '';
 
-            if (mysqli_num_rows($result) == 0) {
-                echo "<img src='".CONFIG_CDN_IMAGES."/icons/error.png' alt='error' id='szukaj_img_error_gk_not_found' width='16' height='16' /> "._('GeoKret not found');
-                exit;
-            } else {
-                while ($row = mysqli_fetch_array($result)) {
-                    list($id, $typ, $nazwa, $userid, $username, $data, $waypoint, $logtype, $name, $lat, $lon) = $row;
+                if (mysqli_num_rows($result) == 0) {
+                    echo "<img src='".CONFIG_CDN_IMAGES."/icons/error.png' alt='error' id='szukaj_img_error_gk_not_found' width='16' height='16' /> "._('GeoKret not found');
+                    exit;
+                } else {
+                    while ($row = mysqli_fetch_array($result)) {
+                        list($id, $typ, $nazwa, $userid, $username, $data, $waypoint, $logtype, $name, $lat, $lon) = $row;
 
-                    if ($waypoint == '') {
-                        $opis = "$lat, $lon";
-                    } else {
-                        $opis = "$waypoint $name ($data)";
+                        if ($waypoint == '') {
+                            $opis = "$lat, $lon";
+                        } else {
+                            $opis = "$waypoint $name ($data)";
+                        }
+
+                        if ($logtype != '') {
+                            $lastlog = _('Last log:')." <img src='".CONFIG_CDN_IMAGES."/log-icons/$typ/2$logtype.png' alt='logtype' title='log' /> $opis";
+                        } else {
+                            $lastlog = '';
+                        }
+
+                        if ($ret != '') {
+                            $ret .= '<br />';
+                        }
+                        $ret .= "<img src='".CONFIG_CDN_IMAGES."/icons/ok.png' alt='OK' id='szukaj_img_ok_gk_".$id."' width='16' height='16' /> ".sprintf(_('%s by %s.'), "<a href='konkret.php?id=$id'>$nazwa</a>", "<a href='mypage.php?userid=$userid'>$username</a>")." $lastlog";
                     }
-
-                    if ($logtype != '') {
-                        $lastlog = _('Last log:')." <img src='".CONFIG_CDN_IMAGES."/log-icons/$typ/2$logtype.png' alt='logtype' title='log' /> $opis";
-                    } else {
-                        $lastlog = '';
-                    }
-
-                    if ($ret != '') {
-                        $ret .= '<br />';
-                    }
-                    $ret .= "<img src='".CONFIG_CDN_IMAGES."/icons/ok.png' alt='OK' id='szukaj_img_ok_gk_".$id."' width='16' height='16' /> ".sprintf(_('%s by %s.'), "<a href='konkret.php?id=$id'>$nazwa</a>", "<a href='mypage.php?userid=$userid'>$username</a>")." $lastlog";
                 }
-            }
-            echo $ret;
-        } else {
-            echo "<img src='".CONFIG_CDN_IMAGES."/icons/error.png' alt='error' id='szukaj_img_error_invalid_tracking' width='16' height='16' /> "._('Invalid tracking code');
-        }
-    } elseif (!empty($_REQUEST['wpt'])) { // ****************************************  waypoint
-        try {
-            $return['lat'] = '';
-            $return['lon'] = '';
-            $wpt = mysqli_real_escape_string($link, $_REQUEST['wpt']);
-            include_once 'lib/Waypointy.class.php';
-            $waypointy = new Waypointy($link, false);
-            $hasResult = $waypointy->getByWaypoint($wpt);
-            if (!$hasResult) {
-                $return['tresc'] = cacheUnknown();
-                echo json_encode($return);
+                echo $ret;
             } else {
-                $lat = $waypointy->lat;
-                $lon = $waypointy->lon;
-
-                if (!empty(trim($lat)) and !empty(trim($lon))) {
-                    $return['tresc'] = cacheOk($waypointy->waypoint, $waypointy->cache_link, $waypointy->name,
-                      $waypointy->owner, $waypointy->cache_type, $waypointy->country, $waypointy->country_code);
-                    $return['lat'] = $lat;
-                    $return['lon'] = $lon;
+                echo "<img src='".CONFIG_CDN_IMAGES."/icons/error.png' alt='error' id='szukaj_img_error_invalid_tracking' width='16' height='16' /> "._('Invalid tracking code');
+            }
+        } elseif (!empty($_REQUEST['wpt'])) { // ****************************************  waypoint
+            try {
+                $return['lat'] = '';
+                $return['lon'] = '';
+                $wpt = mysqli_real_escape_string($link, $_REQUEST['wpt']);
+                $waypointy = new \Geokrety\Repository\WaypointyRepository($link, false);
+                $hasResult = $waypointy->getByWaypoint($wpt);
+                if (!$hasResult) {
+                    $return['tresc'] = cacheUnknown();
                     echo json_encode($return);
                 } else {
-                    $return['tresc'] = cacheWithoutLatLon($waypointy->waypoint, $waypointy->name, $waypointy->cache_link);
-                    echo json_encode($return);
+                    $lat = $waypointy->lat;
+                    $lon = $waypointy->lon;
+
+                    if (!empty(trim($lat)) and !empty(trim($lon))) {
+                        $return['tresc'] = cacheOk($waypointy->waypoint, $waypointy->cache_link, $waypointy->name,
+                      $waypointy->owner, $waypointy->cache_type, $waypointy->country, $waypointy->country_code);
+                        $return['lat'] = $lat;
+                        $return['lon'] = $lon;
+                        echo json_encode($return);
+                    } else {
+                        $return['tresc'] = cacheWithoutLatLon($waypointy->waypoint, $waypointy->name, $waypointy->cache_link);
+                        echo json_encode($return);
+                    }
                 }
+            } catch (Exception $exc) {
+                $return['tresc'] = handleException($exc);
+                $return['lat'] = '';
+                $return['lon'] = '';
+                echo json_encode($return);
             }
-        } catch (Exception $exc) {
-            $return['tresc'] = handleExeption($exc);
-            $return['lat'] = '';
-            $return['lon'] = '';
+        } elseif (!empty($_REQUEST['NazwaSkrzynki']) and mb_strlen($_REQUEST['NazwaSkrzynki']) < 5) {
+            $return['tresc'] = '<img src="'.CONFIG_CDN_IMAGES.'/icons/error.png" alt="error" id="szukaj_img_error_5car" width="16" height="16" /> '._('Enter at least 5 characters');
+            echo json_encode($return);
+        } elseif (!empty($_REQUEST['NazwaSkrzynki'])) {
+            $waypointy = new \Geokrety\Repository\WaypointyRepository($link, false);
+            try {
+                $return['lat'] = '';
+                $return['lon'] = '';
+                $byNameCount = $waypointy->countDistinctName($_REQUEST['NazwaSkrzynki']);
+                $return['IleSkrzynek'] = $byNameCount;
+
+                if ($byNameCount == 0) {// no result
+                    $return['tresc'] = noCacheFound();
+                } elseif ($byNameCount > 1) {
+                    $maxCache = 4;
+                    if ($byNameCount < $maxCache) {
+                        $return['tresc'] = _('caches match').':<br />';
+                    } else {
+                        $return['tresc'] = sprintf(_('%d caches match (the first %d)'), $byNameCount, $maxCache).':<br />';
+                    }
+                    // listing
+                    $sql = "SELECT `waypoint`, `name`, `owner`, `typ`, `kraj`, `link`, `lat`, `lon` FROM `gk-waypointy` WHERE `name` LIKE '%".mysqli_real_escape_string($link, $_REQUEST['NazwaSkrzynki'])."%' LIMIT $maxCache";
+                    $result = mysqli_query($link, $sql);
+                    $result_index = 0;
+                    while ($row = mysqli_fetch_array($result)) {
+                        list($waypoint, $name, $owner, $typ, $kraj, $cache_link, $lat, $lon) = $row;
+                        $ownerPlaceholder = '';
+                        if (trim($owner) !== '') {
+                            $ownerPlaceholder = ' ('.sprintf(_('by %s'), $owner).')';
+                        }
+                        $return['tresc'] .= '<a href="#" id="szukaj_wpt_'.$result_index.'" onclick="document.getElementById(\'wpt\').value = \''.$waypoint.'\'; sprawdzWpt(); return false;"><i class="glyphicon glyphicon-pushpin"></i> '.$waypoint.'</a> - <span class="bardzomale"><a href="'.$cache_link.'" id="szukaj_cache_link_'.$result_index.'" target="_opencaching">'.$name.' <i class="glyphicon glyphicon-link"></i></a>'.$ownerPlaceholder.'</span><br />';
+                        ++$result_index;
+                    }
+                } else { // == 1
+                    $hasResult = $waypointy->getByName($_REQUEST['NazwaSkrzynki']);
+                    if (!$hasResult) {// never the case
+                        $return['tresc'] = cacheUnknown();
+                    } elseif (!empty(trim($waypointy->lat)) and !empty(trim($waypointy->lon))) {
+                        $return['tresc'] = cacheOk($waypointy->waypoint, $waypointy->cache_link, $waypointy->name,
+                      $waypointy->owner, $waypointy->cache_type, $waypointy->country, $waypointy->country_code);
+                        $return['lat'] = $waypointy->lat;
+                        $return['lon'] = $waypointy->lon;
+                        $return['wpt'] = $waypointy->waypoint;
+                    } else {
+                        $return['tresc'] = cacheWithoutLatLon($waypointy->waypoint, $waypointy->name, $waypointy->cache_link);
+                        $return['wpt'] = $waypointy->waypoint;
+                    }
+                } // jeśli jest jedna skrzynka
+            } catch (Exception $exc) {
+                $return['tresc'] = handleException($exc);
+                $return['lat'] = '';
+                $return['lon'] = '';
+            }
             echo json_encode($return);
         }
-    } elseif (!empty($_REQUEST['NazwaSkrzynki']) and mb_strlen($_REQUEST['NazwaSkrzynki']) < 5) {
-        $return['tresc'] = '<img src="'.CONFIG_CDN_IMAGES.'/icons/error.png" alt="error" id="szukaj_img_error_5car" width="16" height="16" /> '._('Enter at least 5 characters');
-        echo json_encode($return);
-    } elseif (!empty($_REQUEST['NazwaSkrzynki'])) {
-        include_once 'lib/Waypointy.class.php';
-        $waypointy = new Waypointy($link, false);
-        try {
-            $return['lat'] = '';
-            $return['lon'] = '';
-            $byNameCount = $waypointy->countDistinctName($_REQUEST['NazwaSkrzynki']);
-            $return['IleSkrzynek'] = $byNameCount;
-
-            if ($byNameCount == 0) {// no result
-                $return['tresc'] = noCacheFound();
-            } elseif ($byNameCount > 1) {
-                $maxCache = 4;
-                if ($byNameCount < $maxCache) {
-                    $return['tresc'] = _('caches match').':<br />';
-                } else {
-                    $return['tresc'] = sprintf(_('%d caches match (the first %d)'), $byNameCount, $maxCache).':<br />';
-                }
-                // listing
-                $sql = "SELECT `waypoint`, `name`, `owner`, `typ`, `kraj`, `link`, `lat`, `lon` FROM `gk-waypointy` WHERE `name` LIKE '%".mysqli_real_escape_string($link, $_REQUEST['NazwaSkrzynki'])."%' LIMIT $maxCache";
-                $result = mysqli_query($link, $sql);
-                $result_index = 0;
-                while ($row = mysqli_fetch_array($result)) {
-                    list($waypoint, $name, $owner, $typ, $kraj, $cache_link, $lat, $lon) = $row;
-                    $ownerPlaceholder = '';
-                    if (trim($owner) !== '') {
-                        $ownerPlaceholder = ' ('.sprintf(_('by %s'), $owner).')';
-                    }
-                    $return['tresc'] .= '<a href="#" id="szukaj_wpt_'.$result_index.'" onclick="document.getElementById(\'wpt\').value = \''.$waypoint.'\'; sprawdzWpt(); return false;"><i class="glyphicon glyphicon-pushpin"></i> '.$waypoint.'</a> - <span class="bardzomale"><a href="'.$cache_link.'" id="szukaj_cache_link_'.$result_index.'" target="_opencaching">'.$name.' <i class="glyphicon glyphicon-link"></i></a>'.$ownerPlaceholder.'</span><br />';
-                    ++$result_index;
-                }
-            } else { // == 1
-                $hasResult = $waypointy->getByName($_REQUEST['NazwaSkrzynki']);
-                if (!$hasResult) {// never the case
-                    $return['tresc'] = cacheUnknown();
-                } elseif (!empty(trim($waypointy->lat)) and !empty(trim($waypointy->lon))) {
-                    $return['tresc'] = cacheOk($waypointy->waypoint, $waypointy->cache_link, $waypointy->name,
-                      $waypointy->owner, $waypointy->cache_type, $waypointy->country, $waypointy->country_code);
-                    $return['lat'] = $waypointy->lat;
-                    $return['lon'] = $waypointy->lon;
-                    $return['wpt'] = $waypointy->waypoint;
-                } else {
-                    $return['tresc'] = cacheWithoutLatLon($waypointy->waypoint, $waypointy->name, $waypointy->cache_link);
-                    $return['wpt'] = $waypointy->waypoint;
-                }
-            } // jeśli jest jedna skrzynka
-        } catch (Exception $exc) {
-            $return['tresc'] = handleExeption($exc);
-            $return['lat'] = '';
-            $return['lon'] = '';
-        }
-        echo json_encode($return);
+        mysqli_close($link);
+        $link = null; // prevent possible warning from smarty.php
     }
-    mysqli_close($link);
-    $link = null; // prevent possible warning from smarty.php
+} catch (Exception $exc) {
+    unexpectedError('Service unavailable - '.$exc->getMessage());
 }

--- a/website/szukaj.php
+++ b/website/szukaj.php
@@ -2,81 +2,82 @@
 
 require_once '__sentry.php';
 
-// smarty cache -- above this declaration should be wybierz_jezyk.php!
+try {
+    // smarty cache -- above this declaration should be wybierz_jezyk.php!
 $smarty_cache_this_page = 0; // this page should be cached for n seconds
 require_once 'smarty_start.php';
 
-$TYTUL = _('Search');
+    $TYTUL = _('Search');
 
-$g_country = $_GET['country'];
-// autopoprawione...
-$g_gk = $_GET['gk'];
-// autopoprawione...
-$g_nr = $_GET['nr'];
-// autopoprawione...
-$g_owner = $_GET['owner'];
-// autopoprawione...
-$g_wpt = $_GET['wpt'];
-// autopoprawione...
-$g_nazwa = $_GET['nazwa'];
-// autopoprawione...import_request_variables('g', 'g_');
+    $g_country = $_GET['country'];
+    // autopoprawione...
+    $g_gk = $_GET['gk'];
+    // autopoprawione...
+    $g_nr = $_GET['nr'];
+    // autopoprawione...
+    $g_owner = $_GET['owner'];
+    // autopoprawione...
+    $g_wpt = $_GET['wpt'];
+    // autopoprawione...
+    $g_nazwa = $_GET['nazwa'];
+    // autopoprawione...import_request_variables('g', 'g_');
 
-require_once 'szukaj_kreta.php';
+    require_once 'szukaj_kreta.php';
 
-$link = DBConnect();
+    $link = GKDB::getLink();
 
-/*
-if(!empty($g_nr)){
-$g_nr=substr($g_nr, 0, 6);
-$TRESC = szukaj_kreta("WHERE `nr`='$g_nr'", 1, "GeoKrety");
-}
-*/
-
-if (!empty($g_gk)) {
-    $gk = hexdec(substr($g_gk, 2, 5));
-    $TRESC = szukaj_kreta("WHERE `id` = '$gk'", 1, 'GeoKrety');
-} elseif (!empty($g_nazwa)) {
-    $g_nazwa = mysqli_real_escape_string($link, htmlentities(trim($g_nazwa)));
-    $TRESC = szukaj_kreta("WHERE `gk-geokrety`.`nazwa` LIKE '%$g_nazwa%'", 200, 'GeoKrety');
-} elseif (!empty($g_owner)) {
-    $g_owner = mysqli_real_escape_string($link, htmlentities(trim($g_owner)));
-    $TRESC = '<h2>'._('Found users').'</h2>';
-    $result = mysqli_query($link, "SELECT `user`, `userid` FROM `gk-users` WHERE (`user` LIKE '%$g_owner%') OR (`userid`='$g_owner') LIMIT 50");
-    while ($row = mysqli_fetch_array($result)) {
-        list($user, $userid) = $row;
-        $TRESC .= "<a href=\"mypage.php?userid=$userid\">$user</a><br />";
+    /*
+    if(!empty($g_nr)){
+    $g_nr=substr($g_nr, 0, 6);
+    $TRESC = szukaj_kreta("WHERE `nr`='$g_nr'", 1, "GeoKrety");
     }
-    mysqli_free_result($result);
-} elseif (!empty($g_wpt)) {
-    $g_owner = mysqli_real_escape_string($link, $g_wpt);
-    include_once 'recent_moves.php';
-    $OGON .= '<script type="text/javascript" src="sorttable.min.js"></script>';
-    $OGON .= '<script type="text/javascript" src="'.$config['ajaxtooltip.js'].'"></script>';
-    $TRESC .= recent_moves("WHERE `waypoint` = '$g_wpt'", 1170, _('Geokrety visiting the cache')." $g_wpt", '', 1);
-} elseif (!empty($g_country)) {
-    $g_country = mysqli_real_escape_string($link, $g_country);
-    $TRESC = '<h2>'._('Geokrets in')." $g_country</h2>".'<p><img src="'.CONFIG_CDN_COUNTRY_FLAGS.'/'.$g_country.'.png" alt="flag" width="16" height="11" border="0" /></p>';
-    $result = mysqli_query($link,
-        "SELECT `gk-ostatnieruchy`.id, `gk-geokrety`.nazwa, `gk-geokrety`.owner, `gk-users`.user
+    */
+
+    if (!empty($g_gk)) {
+        $gk = hexdec(substr($g_gk, 2, 5));
+        $TRESC = szukaj_kreta("WHERE `id` = '$gk'", 1, 'GeoKrety');
+    } elseif (!empty($g_nazwa)) {
+        $g_nazwa = mysqli_real_escape_string($link, htmlentities(trim($g_nazwa)));
+        $TRESC = szukaj_kreta("WHERE `gk-geokrety`.`nazwa` LIKE '%$g_nazwa%'", 200, 'GeoKrety');
+    } elseif (!empty($g_owner)) {
+        $g_owner = mysqli_real_escape_string($link, htmlentities(trim($g_owner)));
+        $TRESC = '<h2>'._('Found users').'</h2>';
+        $result = mysqli_query($link, "SELECT `user`, `userid` FROM `gk-users` WHERE (`user` LIKE '%$g_owner%') OR (`userid`='$g_owner') LIMIT 50");
+        while ($row = mysqli_fetch_array($result)) {
+            list($user, $userid) = $row;
+            $TRESC .= "<a href=\"mypage.php?userid=$userid\">$user</a><br />";
+        }
+        mysqli_free_result($result);
+    } elseif (!empty($g_wpt)) {
+        $g_owner = mysqli_real_escape_string($link, $g_wpt);
+        include_once 'recent_moves.php';
+        $OGON .= '<script type="text/javascript" src="sorttable.min.js"></script>';
+        $OGON .= '<script type="text/javascript" src="'.$config['ajaxtooltip.js'].'"></script>';
+        $TRESC .= recent_moves("WHERE `waypoint` = '$g_wpt'", 1170, _('Geokrety visiting the cache')." $g_wpt", '', 1);
+    } elseif (!empty($g_country)) {
+        $g_country = mysqli_real_escape_string($link, $g_country);
+        $TRESC = '<h2>'._('Geokrets in')." $g_country</h2>"
+        .'<p><img src="'.CONFIG_CDN_COUNTRY_FLAGS.'/'.$g_country.'.png" alt="flag" width="16" height="11" border="0" /></p>';
+        $result = mysqli_query(
+          $link,
+          "SELECT `gk-ostatnieruchy`.id, `gk-geokrety`.nazwa, `gk-geokrety`.owner, `gk-users`.user
 FROM `gk-ostatnieruchy`
 LEFT JOIN `gk-geokrety` ON `gk-geokrety`.id = `gk-ostatnieruchy`.id
 LEFT JOIN `gk-users` ON `gk-users`.userid = `gk-geokrety`.owner
 WHERE `gk-ostatnieruchy`.`logtype` = ( 'O' OR '3' )
 AND `gk-ostatnieruchy`.country = '$g_country'"
-    );
+         );
 
-    while ($row = mysqli_fetch_array($result)) {
-        list($id, $nazwa, $owner, $user) = $row;
-        $TRESC .= "<a href=\"konkret.php?id=$id\">$nazwa</a> by <a href=\"mypage.php?userid=$owner\">$user</a><br />";
-    }
-    mysqli_free_result($result);
-    mysqli_close($link);
-}
-
-// if nothing to search
-
-else {
-    $TRESC = '
+        while ($row = mysqli_fetch_array($result)) {
+            list($id, $nazwa, $owner, $user) = $row;
+            $TRESC .= "<a href=\"konkret.php?id=$id\">$nazwa</a>"
+                    .sprintf(_('by %s'), "<a href=\"mypage.php?userid=$owner\">$user</a>")
+                    .'<br />';
+        }
+        mysqli_free_result($result);
+        mysqli_close($link);
+    } else { //nothing to search
+        $TRESC = '
 <table>
 <form action="'.$_SERVER['PHP_SELF'].'" method="get">
 <tr>
@@ -120,7 +121,10 @@ else {
 </table>
 
 ';
-}
+    }
 
-// --------------------------------------------------------------- SMARTY ---------------------------------------- //
-require_once 'smarty.php';
+    // ------------------------------ SMARTY ------------------------------ //
+    require_once 'smarty.php';
+} catch (Exception $exc) {
+    echo 'Service unavailable - '.$exc->getMessage();
+}

--- a/website/templates/konfig-credits.php
+++ b/website/templates/konfig-credits.php
@@ -2,6 +2,7 @@
 
 if (!isset($config)) {
     $config = array();
+    $config['gk_credits'] = array();
 }
 
 $config['gk_credits'][] = [

--- a/website/waypoint_info.php
+++ b/website/waypoint_info.php
@@ -1,7 +1,8 @@
 <?php
 
 //
-// @deprecated : please use lib/Waypointy.class.php instead, cf. szukaj-ajax.php for usage example
+// @deprecated : please use \Geokrety\Repository\WaypointyRepository instead
+// cf. szukaj-ajax.php for usage example
 //
 // seeks waypoint in the database and returns details
 


### PR DESCRIPTION
- use singleton pattern to avoid duplicate connect for each request
- DBConnect updated usages: DBConnect => GKDB::getLink();

==> this PR should fix  #212 : fix or "reduce" in the way that a given database link could always report unavailability error over the time ;)

Done actions
- [x] local tests
- [x] report install requirement (windows usage) : done in `tests/README.md`
- [x] prevent GKDB::clone ([exemple](https://stackoverflow.com/questions/21832809/php-singleton-database-connection-pattern))
- [x] improve GKDB unit tests (including disconnect/reconnect usecase)
- [x] test daily mail : `geokrety/geokrety-scripts/blob/master/obserwacje2.php`
(from [crontab](https://github.com/geokrety/geokrety-scripts/blob/master/geokrety-crontab))
      not included in `gk alias` but to trace : `alias gk_daily='winpty docker exec -it devGeokrety sh -c "cd /opt/geokrety-scripts/ && php obserwacje2.php"'`
- [x] gkShell/README.md : add `gk tests` command
- [x] -- wait for [PR219](https://github.com/geokrety/geokrety-website/pull/219)
- [x] -- wait for a fix of [226](https://github.com/geokrety/geokrety-website/issues/226)
- [x] (re)test DBConnect replacement branch ([boly38.staging](https://boly38.staging.geokrety.org/))

Limitations:
- (skipped) add SQL sample ruchy content => postponed
- some code style/hound fix have been included into the same commit :/
- reference to 211 is for discussion part only, this PR dont fix recent_move missing check