### PR TITLE
Fixes #261 Broken ruchy action using found waypoint

### DIFF
--- a/website/ruchy.js
+++ b/website/ruchy.js
@@ -61,6 +61,21 @@ function setBorderColorGreen(obj) {
 }
 window['setBorderColorGreen'] = setBorderColorGreen;
 
+/**
+ * executed before submit formularz
+ */
+function onSubmitRuchy() {
+  // re enable fields to get their values
+  var poleWpt = $('#wpt');
+  var poleLatlon = $('#latlon');
+  poleLatlon.prop('disabled', false);
+  poleWpt.prop('disabled', false);
+  $('#js').value=1;
+
+  return validateAddRuchy(this);
+}
+
+
 // ----------------------------------------------------- geolocation -------------------------------------
 function validateAddRuchy(thisForm) {
   var ret = false;

--- a/website/ruchy.php
+++ b/website/ruchy.php
@@ -701,7 +701,7 @@ if ($kret_formname == 'ruchy') { //  **************************************** OP
     }
     // ------------ home coordinates? -------------- //
 
-    $TRESC .= '<form name="formularz" action="'.$_SERVER['PHP_SELF'].$get_czy_edycja.'" onsubmit="this.js.value=1; return validateAddRuchy(this);" method="post" class="form-horizontal"><input type="hidden" name="formname" value="ruchy" />';
+    $TRESC .= '<form name="formularz" action="'.$_SERVER['PHP_SELF'].$get_czy_edycja.'" onsubmit="onSubmitRuchy()" method="post" class="form-horizontal"><input type="hidden" name="formname" value="ruchy" />';
 
     $step_number = 1;
 
@@ -946,7 +946,9 @@ if ($kret_formname == 'ruchy') { //  **************************************** OP
     }
 
     // -------------------- 4 (additional data)
-    $OGON .= "<script>
+    $OGON .= "<script type=\"text/javascript\">
+    // <![CDATA[
+
     $(function () {
       $('.input-group.date').datepicker({
         format: \"yyyy-mm-dd\",
@@ -965,6 +967,8 @@ if ($kret_formname == 'ruchy') { //  **************************************** OP
         alwaysShow: true
       });
     })
+
+    // ]]>
     </script>\n";
     $TRESC .= '
 


### PR DESCRIPTION
**Problem**

when ruchy form found a valid waypoint according to the name (`NazwaSkrzynki`) field, then `wpt` and `latlon` fields are disabled. 

On form submit, disabled fields are not sent to the server.

**Fix** (#261)
- move dedicated `onSubmit` javascript function into `ruchy.js`
- add re-enable `wpt`/`latlon` fields