### PR TITLE
Bugfix 271 missing legend and fix 272 js/css cdn

### DIFF
--- a/website/geokret_gallery.php
+++ b/website/geokret_gallery.php
@@ -61,7 +61,7 @@ if (($p_formname == 'newavatar') and $allowed_to_modify and ctype_digit($p_avata
 } elseif ($errors == '') {
     //standard gallery
     $OGON .= '<script type="text/javascript" src="'.$config['ajaxtooltip.js'].'"></script>';
-    $OGON .= '<script type="text/javascript" src="'.$config['colorbox.js'].'"></script><link rel="stylesheet" type="text/css" href="'.$config['colorbox.css'].'" media="screen"/>';
+    $OGON .= '<script type="text/javascript" src="'.CDN_COLORBOX_JS.'"></script><link rel="stylesheet" type="text/css" href="'.CDN_COLORBOX_CSS.'" media="screen"/>';
     $OGON .= '
 			<script>
 				$(document).ready(function(){

--- a/website/konkret.php
+++ b/website/konkret.php
@@ -293,13 +293,12 @@ $TRESC = $claim_alert.'
 </table>
 
 <table width="100%">
-<tr><td class="heading1"><img src="'.CONFIG_CDN_ICONS.'/info.png" alt="Comment:" width="22" height="22" /></td></tr>
-
+<tr><td class="heading1"><img src="'.CONFIG_CDN_ICONS.'/info.png" alt="Comment:" width="22" height="22" /> '._('Comment').'</td></tr>
 <tr><td class="tresc1" title="'._('Short description').'">'.$opis.'</td></tr>
-<tr><td align="right">'.$add_image.' '.$edit_kreta.'</td></tr>
+<tr><td class="right">'.$add_image.' '.$edit_kreta.'</td></tr>
 <tr><td class="tresc1">'.$MAIN_PHOTO.'</td></tr>
 
-<tr><td class="heading1"><img src="'.CONFIG_CDN_ICONS.'/tool.png" alt="Links:" width="22" height="22" /></td></tr>
+<tr><td class="heading1"><img src="'.CONFIG_CDN_ICONS.'/tool.png" alt="Links:" width="22" height="22" /> '._('Actions').'</td></tr>
 
 </table>
 <table class="tresc1">
@@ -335,6 +334,18 @@ if ($skrzynki <= 0) { // no trip
   <script type="text/javascript" src="konkret.js"></script>
 EOHEAD;
 
+    $mapLegend = '<img src="'.CONFIG_CDN_PINS_ICONS.'/red.png" alt="[Red flag]" width="12" height="20" /> = '._('start').'
+                  <img src="'.CONFIG_CDN_PINS_ICONS.'/yellow.png" alt="[Yellow flag]" width="12" height="20" /> = '._('trip points').'
+                  <img src="'.CONFIG_CDN_PINS_ICONS.'/green.png" alt="[Green flag]" width="12" height="20" /> = '._('recently seen');
+
+    $TRESC .= '<table width="100%">
+<tr><td class="heading1" colspan="2"><a name="map"></a><img src="'.CONFIG_CDN_ICONS.'/mapa.png" alt="Map:" width="22" height="22" /> '._('Map').'</td></tr>
+<tr>
+  <td>'._('Legend').' : '.$mapLegend.'</td>
+  <td class="right">'._('Download the track as:').' <a href="'.$tripService->getTripGpxFilename($kret_id).'">gpx.gz</a> | <a href="'.$tripService->getTripCsvFilename($kret_id).'">csv.gz</a></td>
+</tr>
+</table>';
+
     // bridge from php translated message and id to javascript map functions (cf konkret.js)
     $TRESC .= '
     <div id="mapid" class="gmapa" style="z-index:0;">
@@ -350,7 +361,6 @@ EOHEAD;
     // ]]>
     </script>
 ';
-    $TRESC .= _('Download the track as:')." <a href='".$tripService->getTripGpxFilename($kret_id)."'>gpx.gz</a> | <a href='".$tripService->getTripCsvFilename($kret_id)."'>csv.gz</a>";
     $TRESC .= $TABELKA;
 }
 

--- a/website/konkret.php
+++ b/website/konkret.php
@@ -319,14 +319,12 @@ if ($skrzynki <= 0) { // no trip
 } else { // ($skrzynki > 0) // legacy - we must have downloadable csv and gpx files
     $tripService->ensureGeneratedFiles($id);
 
-    // manage trip map ******************************* // leafletjs CDN
+    // manage trip map ******************************* // geokrety CDN
+    $leafletCss = CDN_LEAFLET_CSS;
+    $leafletJs = CDN_LEAFLET_JS;
     $HEAD .= <<<EOHEAD
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.4.0/dist/leaflet.css"
-    integrity="sha512-puBpdR0798OZvTTbP4A8Ix/l+A4dHDD0DGqYW6RQ+9jxkRFclaxxQb/SJAWZfWAkuyeQUytO7+7N4QKrDh+drA=="
-    crossorigin=""/>
-  <script src="https://unpkg.com/leaflet@1.4.0/dist/leaflet.js"
-   integrity="sha512-QVftwZFqvtRNi0ZyCtsznlKSWOStnDORoefr1enyq5mVL4tmKB3S/EnC3rRJcxCPavG10IcrVGSmPh6Qw5lwrg=="
-   crossorigin=""></script>
+  <link rel="stylesheet" href="$leafletCss"/>
+  <script src="$leafletJs"></script>
   <script type="text/javascript" src="konkret.js"></script>
 EOHEAD;
 
@@ -399,7 +397,7 @@ $TRESC .= '
 // ----------------------------------------------JSON-LD-(end)---------------------
 
 $TYTUL = $nazwa;
-$OGON .= '<script type="text/javascript" src="'.$config['colorbox.js'].'?ver=1.1"></script>
+$OGON .= '<script type="text/javascript" src="'.CDN_COLORBOX_JS.'?ver=1.1"></script>
 <script type="text/javascript" src="'.$config['funkcje.js'].'"></script>
 <script type="text/javascript" src="/templates/rating/jquery/jRating.jquery.js"></script>
 <script type="text/javascript">
@@ -429,7 +427,7 @@ $(document).ready(function(){
 });".'
 </script>
 <link rel="stylesheet" type="text/css" href="/templates/rating/jquery/jRating.jquery.css?ver=1.2" media="screen" />
-<link rel="stylesheet" type="text/css" href="'.$config['colorbox.css'].'?ver=1.2" media="screen"/>
+<link rel="stylesheet" type="text/css" href="'.CDN_COLORBOX_CSS.'" media="screen"/>
 ';
 
 $OGON .= '

--- a/website/konkret.php
+++ b/website/konkret.php
@@ -262,23 +262,19 @@ if ($userRated == 0 and $currentUserKnowsTC == 1 and $ownerIsLogged != 1) {
 
 // <div itemscope itemtype="http://schema.org/Sculpture">
 $TRESC = $claim_alert.'
-<!-- css to move to CDN ? hard to maintain..-->
-<style>
-.konkretlabel {white-space: nowrap;}
-</style>
 <table width="100%">
 <tr><td class="heading1" colspan="2"><img src="'.CONFIG_CDN_IMAGES.'/log-icons/'.$krettyp.'/icon_25.jpg" alt="Info:" width="25" height="25" /> GeoKret <strong>'.$nazwa.'</strong> ('.$cotozakret[$krettyp].') '.
 (($userid > 0) ? ('by <a href="mypage.php?userid='.$userid.'">'.$user.'</a>'.' '.$wyslij_wiadomosc) : ' - unclaimed').
 '</td></tr>
 
 <tr>
-<td class="tresc1 konkretlabel" style="width:10em">Reference Number:</td><td><strong>'.$geokretyGKCode.'</strong></td></tr>
+<td class="tresc1 wsnowrap" style="width:10em">Reference Number:</td><td><strong>'.$geokretyGKCode.'</strong></td></tr>
 '.$tracking_code.'
-<tr><td class="tresc1 konkretlabel">'._('Total distance').': </td><td><strong>'.$droga_total.' km</strong></td></tr>
-<tr><td class="tresc1 konkretlabel">'._('Places visited').': </td><td><strong>'.$skrzynki.'</strong></td></tr>
-<tr><td class="tresc1 konkretlabel">'._('Forum links').': </td><td><form name="frm1">'.$link1.' '.$link2.'</form></td></tr>
-<tr><td class="tresc1 konkretlabel">'._('Country track').': </td><td>'.$cykl_flag.'</td></tr>
-<tr><td class="tresc1 konkretlabel">'._('Rating').': </td>
+<tr><td class="tresc1 wsnowrap">'._('Total distance').': </td><td><strong>'.$droga_total.' km</strong></td></tr>
+<tr><td class="tresc1 wsnowrap">'._('Places visited').': </td><td><strong>'.$skrzynki.'</strong></td></tr>
+<tr><td class="tresc1 wsnowrap">'._('Forum links').': </td><td><form name="frm1">'.$link1.' '.$link2.'</form></td></tr>
+<tr><td class="tresc1 wsnowrap">'._('Country track').': </td><td>'.$cykl_flag.'</td></tr>
+<tr><td class="tresc1 wsnowrap">'._('Rating').': </td>
 <td style="padding-top: 10px;"><div class="basic" id="'.$ratingAvg.'+'.$id.'+'.$userid_longin.'+'.$ratingSha.'+'.$lang.'"></div>
 <span class="szare">'._('votes').': '.$ratingCount.', '._('average rating').
 ': '.$ratingAvg.'. '.$userCanRateThisGK.'.</span>

--- a/website/templates/konfig.php
+++ b/website/templates/konfig.php
@@ -104,11 +104,15 @@ define('CONFIG_CDN_MAPS', $config['cdn_maps']);
 //js
 $config['funkcje.js'] = '/funkcje.js';
 $config['ajaxtooltip.js'] = CONFIG_CDN_LIBRARIES.'/ajaxtooltip/ajaxtooltip-1.min.js';
-$config['colorbox.js'] = 'https://cdnjs.cloudflare.com/ajax/libs/jquery.colorbox/1.6.4/jquery.colorbox-min.js';
-$config['colorbox.css'] = CONFIG_CDN_LIBRARIES.'/colorbox/colorbox-1.min.css';
 $config['securimage'] = 'templates/libraries/securimage-3.6.7/';
 define('CDN_BOOTSTRAP_DATEPICKER_JS', 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.8.0/js/bootstrap-datepicker.min.js');
 define('CDN_BOOTSTRAP_DATEPICKER_CSS', 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.8.0/css/bootstrap-datepicker3.min.css');
+
+define('CDN_COLORBOX_JS', CONFIG_CDN_LIBRARIES.'/colorbox/1.6.4/jquery.colorbox-min.js');
+define('CDN_COLORBOX_CSS', CONFIG_CDN_LIBRARIES.'/colorbox/colorbox-1.min.css');
+
+define('CDN_LEAFLET_JS', CONFIG_CDN_LIBRARIES.'/leaflet/1.4.0/leaflet.js');
+define('CDN_LEAFLET_CSS', CONFIG_CDN_LIBRARIES.'/leaflet/1.4.0/leaflet.css');
 
 // Default timezone
 $config['timezone'] = 'Europe/Paris';


### PR DESCRIPTION
- Fixes #271 re-add map legend, and add sections labels
- Fixes #272 - konkret - use CDN for js and css (and css replace local konkretlabel by cdn wsnowrap)

@kumy geokrety image are pointing to geokrety CDN by konfig'uration. So Ive some trouble to test non-regression for colorbox related diff. And in addition, I remove arg like `?ver=1.1`for which I don't see the effect. So take care of non regression on this point: I don't see image gallery popin issue on boly38 staging.