### PR TITLE
Add configs and manual for one-click local deploy

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,12 +10,30 @@ If you note other requirements, feel free to add it here.
 * smarty 2 + smarty-gettext plugin
 
 
-## Run Geokrety locally
+## Run Geokrety locally (gkShell)
 
 To run a geokrety instance on your Windows/Linux workstation using Docker :
 
  cf. [gkShell](gkShell/README.md)
 
+
+## Run Geokrety locally (docker-compose)
+
+(Tested on Windows 10)
+
+Pre-requisites:
+- Docker installed
+- Docker-compose installed
+
+One-line run command:
+
+     docker-compose -f docker-compose.local.yml up
+
+Now local instance should be up and running and available at http://localhost:8000/
+
+Empty database with proper schema was initialized and exposed on local port `13306`.
+
+Errors are logged in `gk-errory` table in the database
 
 ## How to install contributors tools
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,34 @@
+version: '3.3'
+services:
+    web:
+        build: .
+        image: geokrety:local
+        ports:
+            - "8000:80"
+        volumes:
+            - ${PWD}/website/:/var/www/html/:rw
+            - ${PWD}/configs/ssmtp.tmpl.conf:/etc/ssmtp/ssmtp.conf:ro
+        depends_on:
+            - db
+        environment:
+            DB_HOSTNAME: db
+            DB_USERNAME: geokrety
+            DB_PASSWORD: geokrety
+            DB_NAME: geokrety-db
+            SERVER_URL: "localhost:8000"
+
+    db:
+        image: mysql:5.7
+        volumes:
+            - ./db_data:/var/lib/mysql
+            # Initial DB schema structure
+            - ${PWD}/docker/mariadb:/tmp/database
+        restart: always
+        environment:
+            MYSQL_ROOT_PASSWORD: ge0krety
+            MYSQL_DATABASE: geokrety-db
+            MYSQL_USER: geokrety
+            MYSQL_PASSWORD: geokrety
+        ports:
+            - "13306:3306"
+        command: mysqld --init-file="/tmp/database/00_database-create-geokrety-db.sql"

--- a/website/templates/konfig.php
+++ b/website/templates/konfig.php
@@ -18,8 +18,12 @@ $config['cdn_url'] = isset($_ENV['CDN_SERVER_URL']) ? $_ENV['CDN_SERVER_URL'] : 
 $GOOGLE_MAP_KEY = isset($_ENV['GOOGLE_MAP_KEY']) ? $_ENV['GOOGLE_MAP_KEY'] : 'xxx';
 
 // reCaptcha Api key
-$GOOGLE_RECAPTCHA_PUBLIC_KEY = isset($_ENV['GOOGLE_RECAPTCHA_PUBLIC_KEY']) ? $_ENV['GOOGLE_RECAPTCHA_PUBLIC_KEY'] : 'xxx';
-$GOOGLE_RECAPTCHA_SECRET_KEY = isset($_ENV['GOOGLE_RECAPTCHA_SECRET_KEY']) ? $_ENV['GOOGLE_RECAPTCHA_SECRET_KEY'] : 'xxx';
+if (isset($_ENV['GOOGLE_RECAPTCHA_PUBLIC_KEY'])) {
+    $GOOGLE_RECAPTCHA_PUBLIC_KEY = $_ENV['GOOGLE_RECAPTCHA_PUBLIC_KEY'];
+}
+if (isset($_ENV['GOOGLE_RECAPTCHA_SECRET_KEY'])) {
+    $GOOGLE_RECAPTCHA_SECRET_KEY = $_ENV['GOOGLE_RECAPTCHA_SECRET_KEY'];
+}
 
 // Password hashing
 // Crypt alorythms https://en.wikipedia.org/wiki/Crypt_(C)#Key_derivation_functions_supported_by_crypt


### PR DESCRIPTION
I find existing `gkshell` process not really intuitive and too complex for local development and testing, especially for very basic testing. Also it uses out-of-date docker-machine (see #379).

So I created simple docker-compose file and database so it's possible to get service running in one click without additional requirements.