### PR TITLE
db: add table for last sync and fix default values

### DIFF
--- a/docker/mariadb/02_add_waypoint_sync.sql
+++ b/docker/mariadb/02_add_waypoint_sync.sql
@@ -1,0 +1,29 @@
+ALTER TABLE `gk-waypointy`
+  ALTER `kraj` DROP DEFAULT;
+ALTER TABLE `gk-waypointy`
+  CHANGE COLUMN `kraj` `kraj` VARCHAR(200) NULL COLLATE 'utf8_polish_ci' AFTER `typ`;
+
+ALTER TABLE `gk-waypointy`
+  ALTER `lat` DROP DEFAULT,
+  ALTER `lon` DROP DEFAULT,
+  ALTER `name` DROP DEFAULT,
+  ALTER `owner` DROP DEFAULT,
+  ALTER `typ` DROP DEFAULT,
+  ALTER `link` DROP DEFAULT;
+ALTER TABLE `gk-waypointy`
+  CHANGE COLUMN `lat` `lat` DOUBLE(8,5) NULL AFTER `waypoint`,
+  CHANGE COLUMN `lon` `lon` DOUBLE(8,5) NULL AFTER `lat`,
+  CHANGE COLUMN `name` `name` VARCHAR(255) NULL COLLATE 'utf8_polish_ci' AFTER `country`,
+  CHANGE COLUMN `owner` `owner` VARCHAR(150) NULL COLLATE 'utf8_polish_ci' AFTER `name`,
+  CHANGE COLUMN `typ` `typ` VARCHAR(200) NULL COLLATE 'utf8_polish_ci' AFTER `owner`,
+  CHANGE COLUMN `link` `link` VARCHAR(255) NULL COLLATE 'utf8_polish_ci' AFTER `kraj`;
+
+
+CREATE TABLE `gk-waypointy-sync` (
+                                   `service_id` VARCHAR(5) NOT NULL,
+                                   `last_update` VARCHAR(15) NULL DEFAULT NULL
+)
+  COMMENT='Last synchronization time for GC services'
+  COLLATE='utf8_general_ci'
+  ENGINE=InnoDB
+;

--- a/docker/mariadb/02_add_waypoint_sync.sql
+++ b/docker/mariadb/02_add_waypoint_sync.sql
@@ -24,6 +24,6 @@ CREATE TABLE `gk-waypointy-sync` (
                                    `last_update` VARCHAR(15) NULL DEFAULT NULL
 )
   COMMENT='Last synchronization time for GC services'
-  COLLATE='utf8_general_ci'
+  COLLATE='utf8mb4_unicode_ci'
   ENGINE=InnoDB
 ;

--- a/docker/mariadb/02_add_waypoint_sync.sql
+++ b/docker/mariadb/02_add_waypoint_sync.sql
@@ -1,7 +1,7 @@
 ALTER TABLE `gk-waypointy`
   ALTER `kraj` DROP DEFAULT;
 ALTER TABLE `gk-waypointy`
-  CHANGE COLUMN `kraj` `kraj` VARCHAR(200) NULL COLLATE 'utf8_polish_ci' AFTER `typ`;
+  CHANGE COLUMN `kraj` `kraj` VARCHAR(200) NULL COLLATE 'utf8mb4_unicode_ci' COMMENT 'full English country name' AFTER `typ`;
 
 ALTER TABLE `gk-waypointy`
   ALTER `lat` DROP DEFAULT,
@@ -11,12 +11,13 @@ ALTER TABLE `gk-waypointy`
   ALTER `typ` DROP DEFAULT,
   ALTER `link` DROP DEFAULT;
 ALTER TABLE `gk-waypointy`
+  CHANGE `country` `country` char(3) COLLATE 'utf8mb4_unicode_ci' NULL COMMENT 'country code as ISO 3166-1 alpha-2' AFTER `alt`,
   CHANGE COLUMN `lat` `lat` DOUBLE(8,5) NULL AFTER `waypoint`,
   CHANGE COLUMN `lon` `lon` DOUBLE(8,5) NULL AFTER `lat`,
-  CHANGE COLUMN `name` `name` VARCHAR(255) NULL COLLATE 'utf8_polish_ci' AFTER `country`,
-  CHANGE COLUMN `owner` `owner` VARCHAR(150) NULL COLLATE 'utf8_polish_ci' AFTER `name`,
-  CHANGE COLUMN `typ` `typ` VARCHAR(200) NULL COLLATE 'utf8_polish_ci' AFTER `owner`,
-  CHANGE COLUMN `link` `link` VARCHAR(255) NULL COLLATE 'utf8_polish_ci' AFTER `kraj`;
+  CHANGE COLUMN `name` `name` VARCHAR(255) NULL COLLATE 'utf8mb4_unicode_ci' AFTER `country`,
+  CHANGE COLUMN `owner` `owner` VARCHAR(150) NULL COLLATE 'utf8mb4_unicode_ci' AFTER `name`,
+  CHANGE COLUMN `typ` `typ` VARCHAR(200) NULL COLLATE 'utf8mb4_unicode_ci' AFTER `owner`,
+  CHANGE COLUMN `link` `link` VARCHAR(255) NULL COLLATE 'utf8mb4_unicode_ci' AFTER `kraj`;
 
 
 CREATE TABLE `gk-waypointy-sync` (


### PR DESCRIPTION
In order to switch to OKAPI we need to save last revision.
Previous approach was using timestamps and doesn't work any more.

Also since currently changelog may be partial, we need to remove NOT NULL
constraints from gk-waypointy table, so partial update queries may work