### PR TITLE
Fix #491 add developer mode to bypass smtp requirement

### DIFF
--- a/gkShell/docker-compose.yml
+++ b/gkShell/docker-compose.yml
@@ -47,6 +47,7 @@ services:
             - GK_CDN_SERVER_URL=https://new-theme.cdn.geokrety.org
             - GK_SITE_BASE_SERVER_URL=http://gk
             - GK_DEBUG=3
+            - GK_DEV_LOCAL=1
         depends_on:
             - db
             - redis

--- a/gkShell/docker-compose.yml
+++ b/gkShell/docker-compose.yml
@@ -44,7 +44,9 @@ services:
         environment:
             - website_config_directory=/var/www/config
             - MYSQL_ROOT_PASSWORD
-            - CDN_SERVER_URL=https://new-theme.cdn.geokrety.org
+            - GK_CDN_SERVER_URL=https://new-theme.cdn.geokrety.org
+            - GK_SITE_BASE_SERVER_URL=http://gk
+            - GK_DEBUG=3
         depends_on:
             - db
             - redis

--- a/website/app/GeoKrety/Service/Config.php
+++ b/website/app/GeoKrety/Service/Config.php
@@ -70,6 +70,10 @@ class Config {
         define('GK_SMARTY_COMPILE_DIR', $_ENV['GK_SMARTY_COMPILE_DIR'] ?? '/tmp/smarty/compile/');
         define('GK_SMARTY_CACHE_DIR', $_ENV['GK_SMARTY_CACHE_DIR'] ?? '/tmp/smarty/cache/');
 
+        // Local DEV only - disabled by default
+        define('GK_DEV_LOCAL', $_ENV['GK_DEV_LOCAL'] ?? 0);
+        define('GK_DEV_CACHE_DIR', $_ENV['GK_DEV_CACHE_DIR'] ?? './');
+
         // HTMLPurifier
         define('GK_HTMLPURIFIER_CACHE_DIR', $_ENV['GK_HTMLPURIFIER_CACHE_DIR'] ?? '/tmp/htmlpurifier/cache/');
 


### PR DESCRIPTION
Fix #491 add developer mode to bypass smtp requirement

- add local dev config `GK_DEV_LOCAL` : by default = 0 == disabled
- improve AccountActivation : dont send email using smtp when GK_DEV_LOCAL==1

@kumy , what do you think ? test-like oriented feature embeeded into legacy code: I'm not super fan but if you have another suggest, please tell me.