### PR TITLE
Fixes #475 : Remove untranslated text info over string

### DIFF
--- a/website/app-templates/smarty/blocks/geokret/details.tpl
+++ b/website/app-templates/smarty/blocks/geokret/details.tpl
@@ -37,7 +37,7 @@
                     <dt>{t}Reference number{/t}</dt>
                     <dd title="{$geokret->gkid()}">{$geokret->gkid}</dd>
                     {if $geokret->isOwner() or $geokret->hasTouchedInThePast()}
-                    <dt><abbr title="Tracking Code">{t}Tracking Code{/t}</abbr></dt>
+                    <dt>{t}Tracking Code{/t}</dt>
                     <dd><strong>{$geokret->tracking_code}</strong></dd>
                     {/if}
                     <dt>{t}Total distance{/t}</dt>

--- a/website/app-templates/smarty/blocks/geokret/found_it.tpl
+++ b/website/app-templates/smarty/blocks/geokret/found_it.tpl
@@ -6,7 +6,7 @@
         <form class="form form-horizontal" action="{'move_create'|alias}" method="get">
 
             <div class="form-group">
-                <label for="tracking_code" class="col-sm-2 control-label"><abbr title="Tracking Code">{t}Tracking Code{/t}</abbr></label>
+                <label for="tracking_code" class="col-sm-2 control-label">{t}Tracking Code{/t}</label>
                 <div class="col-sm-8">
                     <input class="form-control" type="text" name="tracking_code" id="tracking_code"{if $geokret->isOwner() or $geokret->hasTouchedInThePast()} value="{$geokret->tracking_code}"{/if} size="{GK_SITE_TRACKING_CODE_LENGTH}" maxlength="{GK_SITE_TRACKING_CODE_LENGTH}" placeholder="{t}Please enter the Tracking Code here{/t}">
                 </div>

--- a/website/app-templates/smarty/forms/move.tpl
+++ b/website/app-templates/smarty/forms/move.tpl
@@ -18,7 +18,7 @@
                     <div class="row">
                         <div class="col-sm-8">
                             <div class="form-group">
-                                <label for="nr" class="col-sm-2 control-label"><abbr title="Tracking Code">{t}Tracking Code{/t}</abbr></label>
+                                <label for="nr" class="col-sm-2 control-label">{t}Tracking Code{/t}</label>
                                 <div class="col-sm-10">
 
                                     <div class="input-group">

--- a/website/app-templates/smarty/pages/geokret_claim.tpl
+++ b/website/app-templates/smarty/pages/geokret_claim.tpl
@@ -9,7 +9,7 @@
         <form class="form-horizontal" method="post" id="formClaim" data-parsley-validate data-parsley-priority-enabled=false data-parsley-ui-enabled=true>
 
             <div class="form-group">
-                <label for="inputTrackingCode" class="col-sm-2 control-label"><abbr title="Tracking Code">{t}Tracking Code{/t}</abbr></label>
+                <label for="inputTrackingCode" class="col-sm-2 control-label">{t}Tracking Code{/t}</label>
                 <div class="col-sm-10">
                     <input type="text" class="form-control" id="inputTrackingCode" name="tc" placeholder="ABC123" minlength="6" value="{if isset($smarty.post.tc)}{$smarty.post.tc}{/if}" required>
                 </div>


### PR DESCRIPTION
Remove untranslated text info over string

Fixes the first part of issue [#475](https://github.com/geokrety/geokrety-website/issues/475).