### PR TITLE
Prevent download of external binaries on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ addons:
     packages:
       - moreutils
       - gettext
+      - jq
 
 # https://andidittrich.de/2017/06/travisci-setup-mysql-tablesdata-before-running-tests.html
 before_install:


### PR DESCRIPTION
Relates to comment https://github.com/geokrety/geokrety-website/commit/f0aca70f10be69c5b88efe66234cce2d393d3865#r35551518

`jq` is present in almost all linux distribution. For many reasons
it would be better to use the package from them.

Code not tested, only checked using `shellcheck`. @boly38 what do you think?