### PR TITLE
fix: Account created via OAuth have no password

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -46,6 +46,13 @@ x-variables: &variables
 
 services:
 
+  adminer:
+    image: adminer
+    ports:
+      - 3005:8080
+    environment:
+      ADMINER_DEFAULT_SERVER: postgres
+
   # used to build image only
   website-base:
     image: geokrety/website-legacy-base:php74

--- a/tests-qa/acceptance/070_UserPassword/050_no_old_password.robot
+++ b/tests-qa/acceptance/070_UserPassword/050_no_old_password.robot
@@ -1,0 +1,86 @@
+*** Settings ***
+Library         RequestsLibrary
+Resource        ../functions/FunctionsGlobal.robot
+Resource        ../functions/PagePasswordChange.robot
+Resource        ../vars/users.resource
+Force Tags      Users Details    Security
+Test Setup      Clean
+
+*** Variables ***
+
+&{password_equal}    password_old=password    password_new=mypassword    password_new_confirm=mypassword
+
+&{password_not_equal}    password_old=password    password_new=mypassword    password_new_confirm=bad
+
+&{password_no_old_equal}    password_new=mypassword    password_new_confirm=mypassword
+
+&{password_no_old_not_equal}    password_new=mypassword    password_new_confirm=badpassword
+
+*** Test Cases ***
+
+Field old password visibility - user having a password
+    Seed ${1} users
+    Sign In ${USER_1.name} Fast
+    Go To User 1 url
+    Click Link                              ${USER_PROFILE_PASSWORD_EDIT_BUTTON}
+    Wait Until Modal                        Change your password
+    Page Should Contain Element             ${USER_PASSWORD_OLD_INPUT}
+
+Field old password visibility - user not having a password
+    Seed ${1} users without password
+    Sign In ${USER_1.name} Fast
+    Go To User 1 url
+    Click Link                              ${USER_PROFILE_PASSWORD_EDIT_BUTTON}
+    Wait Until Modal                        Change your password
+    Page Should Not Contain Element         ${USER_PASSWORD_OLD_INPUT}
+
+Old password check - user not having a password
+    Seed ${1} users without password
+    Create Session    gk                            ${GK_URL}
+    ${auth} =         GET On Session      gk        /devel/users/${USER_1.name}/login
+
+    ${resp} =         POST On Session     gk        url=${PAGE_USER_CHANGE_PASSWORD_URL}?skip_csrf=True     data=&{password_no_old_not_equal}    expected_status=200
+    ${body} =         Convert To String   ${resp.content}
+    Should Contain                        ${body}    New passwords doesn't match.
+
+    ${resp} =         POST On Session     gk        url=${PAGE_USER_CHANGE_PASSWORD_URL}?skip_csrf=True     data=&{password_no_old_equal}    expected_status=200
+    ${body} =         Convert To String   ${resp.content}
+    Should Contain                        ${body}    Your password has been changed.
+
+    Delete All Sessions
+
+Old password check - user having a password
+    Seed ${1} users
+    Create Session    gk                            ${GK_URL}
+    ${auth} =         GET On Session      gk        /devel/users/${USER_1.name}/login
+
+    ${resp} =         POST On Session     gk        url=${PAGE_USER_CHANGE_PASSWORD_URL}?skip_csrf=True     data=&{password_not_equal}    expected_status=200
+    ${body} =         Convert To String   ${resp.content}
+    Should Contain                        ${body}    New passwords doesn't match.
+
+    ${resp} =         POST On Session     gk        url=${PAGE_USER_CHANGE_PASSWORD_URL}?skip_csrf=True     data=&{password_equal}    expected_status=200
+    ${body} =         Convert To String   ${resp.content}
+    Should Contain                        ${body}    Your password has been changed.
+
+    Delete All Sessions
+
+Old password check - user having a password - no old password given
+    Seed ${1} users
+    Create Session    gk                            ${GK_URL}
+    ${auth} =         GET On Session      gk        /devel/users/${USER_1.name}/login
+
+    ${resp} =         POST On Session     gk        url=${PAGE_USER_CHANGE_PASSWORD_URL}?skip_csrf=True     data=&{password_no_old_not_equal}    expected_status=200
+    ${body} =         Convert To String   ${resp.content}
+    Should Contain                        ${body}    Please enter your old password.
+
+    ${resp} =         POST On Session     gk        url=${PAGE_USER_CHANGE_PASSWORD_URL}?skip_csrf=True     data=&{password_no_old_equal}    expected_status=200
+    ${body} =         Convert To String   ${resp.content}
+    Should Contain                        ${body}    Please enter your old password.
+
+    Delete All Sessions
+
+*** Keywords ***
+
+Clean
+    Clear Database
+    Sign Out Fast

--- a/tests-qa/acceptance/070_UserPassword/060_missing_password_banner.robot
+++ b/tests-qa/acceptance/070_UserPassword/060_missing_password_banner.robot
@@ -1,0 +1,43 @@
+*** Settings ***
+Resource        ../functions/FunctionsGlobal.robot
+Force Tags      Users Details    Username
+Resource        ../vars/users.resource
+Test Setup     Seed Test
+
+*** Test Cases ***
+
+Anonymous users - doen't see the banner
+    Go To Url                               ${PAGE_HOME_URL}
+    Page Should Not Contain                 Sorry, but your account has no password registered and no OAuth connection.
+
+User with a password - doesn't see the banner
+    Seed 1 users
+    Sign In ${USER_1.name} Fast
+    Go To Url                               ${PAGE_HOME_URL}
+    Page Should Not Contain                 Sorry, but your account has no password registered and no OAuth connection.
+
+User with no password - see the banner
+    Seed 1 users without password
+    Sign In ${USER_1.name} Fast
+    Go To Url                               ${PAGE_HOME_URL}
+    Page Should Contain                     Sorry, but your account has no password registered and no OAuth connection.
+
+User with no password but with social auth - doesn't see the banner
+    Seed ${1} users without password with social_auth_provider_id ${1}
+    Sign In ${USER_1.name} Fast
+    Go To Url                               ${PAGE_HOME_URL}
+    Page Should Not Contain                 Sorry, but your account has no password registered and no OAuth connection.
+
+User with password and with social auth - doesn't see the banner
+    Seed ${1} users with social_auth_provider_id ${1}
+    Sign In ${USER_1.name} Fast
+    Go To Url                               ${PAGE_HOME_URL}
+    Page Should Not Contain                 Sorry, but your account has no password registered and no OAuth connection.
+
+
+
+
+*** Keywords ***
+
+Seed Test
+    Clear Database

--- a/tests-qa/acceptance/106_UserEmailErrorBanners/010_Email_Invalid.robot
+++ b/tests-qa/acceptance/106_UserEmailErrorBanners/010_Email_Invalid.robot
@@ -11,7 +11,6 @@ Banner not visible for logged out users
     Page Should Not Contain                 Sorry, but we have troubles sending you email notifications. Is your email still valid?
     Page Should Not Contain                 Sorry, but your account has no email registered. You will not be able to recover from a password loss! Also, you will not receive daily notifications of your GeoKrety or watched GeoKrety.
 
-
 User with valid email doesn't see the banner
     Seed 1 users
     Sign In ${USER_1.name} Fast

--- a/tests-qa/acceptance/functions/FunctionsGlobal.robot
+++ b/tests-qa/acceptance/functions/FunctionsGlobal.robot
@@ -228,6 +228,10 @@ Seed ${count} users
     Go To Url                           ${PAGE_SEED_USER}/${count}
     Empty Dev Mailbox Fast
 
+Seed ${count} users without password
+    Go To Url                           url=${PAGE_SEED_USER}/${count}?without_password=true
+    Empty Dev Mailbox Fast
+
 Seed ${count} users without terms of use
     Go To Url                           ${PAGE_SEED_USER}/${count}/no-terms-of-use
     Empty Dev Mailbox Fast
@@ -238,6 +242,14 @@ Seed ${count} users with status ${status}
 
 Seed ${count} users without terms of use with status ${status}
     Go To Url                           ${PAGE_SEED_USER}/${count}/status/${status}/no-terms-of-use
+    Empty Dev Mailbox Fast
+
+Seed ${count} users with social_auth_provider_id ${social_auth_provider_id}
+    Go To Url                           url=${PAGE_SEED_USER}/${count}?social_auth_provider_id=${social_auth_provider_id}
+    Empty Dev Mailbox Fast
+
+Seed ${count} users without password with social_auth_provider_id ${social_auth_provider_id}
+    Go To Url                           url=${PAGE_SEED_USER}/${count}?without_password=true&social_auth_provider_id=${social_auth_provider_id}
     Empty Dev Mailbox Fast
 
 Seed ${count} geokrety

--- a/tests-qa/acceptance/functions/FunctionsGlobal.robot
+++ b/tests-qa/acceptance/functions/FunctionsGlobal.robot
@@ -325,6 +325,7 @@ Open Panel
 
 Flash message shown
     [Arguments]  ${message}
+    Page WithoutWarningOrFailure
     Wait until page contains element    //div[contains(@class, "flash-message") and text()[contains(., "${message}")]]
 
 Check Image
@@ -342,6 +343,7 @@ Scroll Into View
 
 Wait Until Modal
     [Arguments]    ${title}
+    Page WithoutWarningOrFailure
     Wait Until Page Contains Element        ${MODAL_DIALOG}
     Wait Until Page Contains Element        ${MODAL_DIALOG_TITLE}
     Wait Until Element Is Visible           ${MODAL_DIALOG}
@@ -355,6 +357,7 @@ Wait Until Modal Close
 
 Wait Until Panel
     [Arguments]    ${title}
+    Page WithoutWarningOrFailure
     Wait Until Page Contains Element        ${MODAL_PANEL}
     Wait Until Page Contains Element        ${MODAL_PANEL_TITLE}
     # Wait Until Page Contains Element        ${MODAL_PANEL_SUBMIT_BUTTON}
@@ -369,6 +372,7 @@ Element Count Should Be
 
 Wait For Text To Not Appear
     [Arguments]    ${expect}    ${timeout}=1
+    Page WithoutWarningOrFailure
     Run Keyword And Expect Error    not seen    Wait Until Page Contains    ${expect}    timeout=${timeout}    error=not seen
 
 Input Value Should Be

--- a/website/app-templates/smarty/banners/user_password_missing.tpl
+++ b/website/app-templates/smarty/banners/user_password_missing.tpl
@@ -1,0 +1,6 @@
+{if isset($current_user) && !$current_user->hasPassword() && !$current_user->isConnectedWithProvider()}
+<div class="alert alert-warning" role="alert">
+    {t escape=no}Sorry, but your account has no password registered and no OAuth connection. <b>You will not be able to login again!</b>{/t}
+  {t escape=no url1='user_update_password'|alias url2='user_details'|alias:sprintf('userid=%d', $current_user->id)}Please consider <a href="%1">setting a password</a> or <a href="%2">link your account</a> with some OAuth provider.{/t}
+</div>
+{/if}

--- a/website/app-templates/smarty/base.tpl
+++ b/website/app-templates/smarty/base.tpl
@@ -10,6 +10,7 @@
         {include file='banners/user_email_missing.tpl'}
         {include file='banners/user_email_invalid.tpl'}
         {include file='banners/user_email_pending_validation.tpl'}
+        {include file='banners/user_password_missing.tpl'}
         {include file='banners/flash_messages.tpl'}
         {block name=content}{/block}
         <div id ="spinner-center" style="top:30%;left:50%;z-index: 3000000000;"></div>

--- a/website/app-templates/smarty/devel/pages/home.tpl
+++ b/website/app-templates/smarty/devel/pages/home.tpl
@@ -20,6 +20,12 @@
                             <a href="{'devel_seed_users_status'|alias:sprintf('@count=%d,@status=%d', 1, GeoKrety\Model\User::USER_ACCOUNT_IMPORTED)}">Seed "1" user with status 'imported'</a>
                         </li>
                         <li>
+                            <a href="{'devel_seed_users'|alias:sprintf('@count=%d', 1)}?social_auth_provider_id=1">Seed "1" user with social_auth_provider_id '1'</a>
+                        </li>
+                        <li>
+                            <a href="{'devel_seed_users'|alias:sprintf('@count=%d', 1)}?without_password=true&social_auth_provider_id=1">Seed "1" user without password with social_auth_provider_id '1'</a>
+                        </li>
+                        <li>
                             <a href="{'devel_seed_geokrety_user'|alias:sprintf('@count=%d,userid=%d', 1, 1)}">Seed "1" GeoKret Owned By user "1"</a>
                         </li>
                         <li>

--- a/website/app-templates/smarty/dialog/user_update_password.tpl
+++ b/website/app-templates/smarty/dialog/user_update_password.tpl
@@ -11,6 +11,7 @@
 <form id="update-password" name="update-password" action="{'user_update_password'|alias}" method="post" class="form-horizontal" data-parsley-validate data-parsley-priority-enabled=false data-parsley-ui-enabled=true>
     <div class="modal-body">
 
+        {if $current_user->hasPassword()}
         <div class="form-group">
             <label for="inputPasswordOld" class="col-sm-2 control-label">{t}Current password{/t}</label>
             <div class="col-sm-8">
@@ -18,6 +19,7 @@
             </div>
         </div>
         <hr />
+        {/if}
         <div class="form-group">
             <label for="inputPasswordNew" class="col-sm-2 control-label">{t}New password{/t}</label>
             <div class="col-sm-8">

--- a/website/app/GeoKrety/Controller/Pages/UserUpdatePassword.php
+++ b/website/app/GeoKrety/Controller/Pages/UserUpdatePassword.php
@@ -31,13 +31,21 @@ class UserUpdatePassword extends Base {
         $user = new User();
         $user->load(['id = ?', $f3->get('SESSION.CURRENT_USER')]);
 
-        // Check old password
-        $auth = new Auth('password', ['id' => 'username', 'pw' => 'password']);
-        $check_result = $auth->login($user->username, $password_old);
-        if (!$check_result) {
-            Flash::instance()->addMessage(_('Your old password is invalid.'), 'danger');
-            $this->get();
-            exit();
+        // Check old password needed?
+        if ($user->hasPassword()) {
+            if (is_null($password_old)) {
+                Flash::instance()->addMessage(_('Please enter your old password.'), 'danger');
+                $this->get();
+                exit();
+            }
+            // Check old password
+            $auth = new Auth('password', ['id' => 'username', 'pw' => 'password']);
+            $check_result = $auth->login($user->username, $password_old);
+            if (!$check_result) {
+                Flash::instance()->addMessage(_('Your old password is invalid.'), 'danger');
+                $this->get();
+                exit();
+            }
         }
 
         // Check passwords are equals

--- a/website/app/GeoKrety/Model/User.php
+++ b/website/app/GeoKrety/Model/User.php
@@ -294,6 +294,10 @@ class User extends Base implements JsonSerializable {
         return $this->email_invalid === self::USER_EMAIL_NO_ERROR;
     }
 
+    public function hasPassword(): bool {
+        return !is_null($this->password);
+    }
+
     public function hasAcceptedTheTermsOfUse(): bool {
         return !is_null($this->terms_of_use_datetime);
     }
@@ -302,7 +306,7 @@ class User extends Base implements JsonSerializable {
         if (is_null($this->social_auth)) {
             return false;
         } elseif (is_null($provider)) {
-            return true;
+            return $this->social_auth->count() > 0;
         }
 
         $prov_ids = $this->social_auth->getAll('provider', true);


### PR DESCRIPTION
- add a banner if neither password or social auth defined for an account
- users without password can define a password