### PR TITLE
add meta tags for previews

### DIFF
--- a/website/app-templates/smarty/head.tpl
+++ b/website/app-templates/smarty/head.tpl
@@ -3,14 +3,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>GeoKrety: {block name=title}{/block}</title>
     <meta name="title" content="GeoKrety"/>
-    <meta name="description" content="Open source item tracking for all geocaching platforms"/>
+    <meta name="description" content="{t}Open source item tracking for all geocaching platforms{/t}"/>
     <meta property="og:type" content="website"/>
     <meta property="og:url" content="https://geokrety.org/"/>
     <meta property="og:title" content="GeoKrety"/>
-    <meta property="og:description" content="Open source item tracking for all geocaching platforms"/>
+    <meta property="og:description" content="{t}Open source item tracking for all geocaching platforms{/t}"/>
     <meta property="twitter:url" content="https://geokrety.org/"/>
     <meta property="twitter:title" content="GeoKrety"/>
-    <meta property="twitter:description" content="Open source item tracking for all geocaching platforms"/>
+    <meta property="twitter:description" content="{t}Open source item tracking for all geocaching platforms{/t}"/>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     {\Assets::instance()->addCss(GK_CDN_BOOTSTRAP_CSS) && ''}
     {\Assets::instance()->addCss(GK_CDN_FONT_AWESOME_CSS) && ''}

--- a/website/app-templates/smarty/head.tpl
+++ b/website/app-templates/smarty/head.tpl
@@ -2,7 +2,15 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>GeoKrety: {block name=title}{/block}</title>
-    <meta name="description" content="" />
+    <meta name="title" content="GeoKrety"/>
+    <meta name="description" content="Open source item tracking for all geocaching platforms"/>
+    <meta property="og:type" content="website"/>
+    <meta property="og:url" content="https://geokrety.org/"/>
+    <meta property="og:title" content="GeoKrety"/>
+    <meta property="og:description" content="Open source item tracking for all geocaching platforms"/>
+    <meta property="twitter:url" content="https://geokrety.org/"/>
+    <meta property="twitter:title" content="GeoKrety"/>
+    <meta property="twitter:description" content="Open source item tracking for all geocaching platforms"/>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     {\Assets::instance()->addCss(GK_CDN_BOOTSTRAP_CSS) && ''}
     {\Assets::instance()->addCss(GK_CDN_FONT_AWESOME_CSS) && ''}


### PR DESCRIPTION
This allows for https://geokrety.org/ to offer a preview when shared in chat platforms or the usual social networks. 