### PR TITLE
fix: Newly created users via gmail button don't have a valid email

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,5 +15,8 @@
         <testsuite name="services">
             <directory>tests/unit/app/GeoKrety/Service/</directory>
         </testsuite>
+        <testsuite name="model">
+            <directory>tests/unit/app/GeoKrety/Model/</directory>
+        </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/unit/app/GeoKrety/Model/UserTest.php
+++ b/tests/unit/app/GeoKrety/Model/UserTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace unit\app\GeoKrety\Model;
+
+use GeoKrety\Model\User;
+use Mockery;
+
+class UserTest extends Mockery\Adapter\Phpunit\MockeryTestCase {
+    public function testHasEmailBase() {
+        $user = new User();
+        $this->assertEquals($user->hasEmail(), false);
+    }
+
+    public function testHasEmailHash() {
+        $user = new User();
+        $user->_email_hash = 'xyz';
+        $this->assertEquals($user->hasEmail(), true);
+    }
+
+    public function testHasEmailJustSet() {
+        $user = new User();
+        $user->_email = 'foobar@example.com';
+        $this->assertEquals($user->hasEmail(), true);
+    }
+}

--- a/website/app/GeoKrety/Model/User.php
+++ b/website/app/GeoKrety/Model/User.php
@@ -345,7 +345,7 @@ class User extends Base implements \JsonSerializable {
     }
 
     public function hasEmail(): bool {
-        return !is_null($this->_email_hash);
+        return !is_null($this->_email_hash) || !is_null($this->_email);
     }
 
     public function isEmailValid(): bool {


### PR DESCRIPTION
Closes #1056