### PR TITLE
fix: Allow "met" moves at the same datetime

### DIFF
--- a/website/db/migrations/20250402131946_same_date_for_met.php
+++ b/website/db/migrations/20250402131946_same_date_for_met.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class SameDateForMet extends AbstractMigration {
+    public function up(): void {
+        $this->execute(<<<'EOL'
+CREATE OR REPLACE FUNCTION geokrety.moves_moved_on_datetime_checker()
+    RETURNS trigger
+    LANGUAGE 'plpgsql'
+    VOLATILE
+    COST 100
+AS $BODY$
+DECLARE
+_geokret gk_geokrety;
+BEGIN
+
+SELECT *
+FROM gk_geokrety
+WHERE id = NEW.geokret
+INTO _geokret;
+
+-- move before GK birth
+IF DATE_TRUNC('MINUTE', NEW.moved_on_datetime) < DATE_TRUNC('MINUTE', _geokret.born_on_datetime) THEN
+	RAISE 'Move date (%) time can not be before GeoKret birth (%)', DATE_TRUNC('MINUTE', NEW.moved_on_datetime), DATE_TRUNC('MINUTE', _geokret.born_on_datetime);
+-- move after NOW()
+ELSIF NEW.moved_on_datetime > NOW()::timestamp(0) THEN
+	RAISE 'The date is in the future (if you are an inventor of a time travelling machine, contact us please!)';
+-- same move on this GK at this datetime
+ELSIF COUNT(*) > 0 FROM gk_moves WHERE moved_on_datetime = NEW.moved_on_datetime AND "geokret" = NEW.geokret AND id != NEW.id AND move_type NOT IN (2::smallint) AND NEW.move_type NOT IN (2::smallint) AND NOT (NEW.move_type IN (3::smallint) AND _geokret.non_collectible IS NOT NULL) THEN
+	RAISE 'A move at the exact same date already exists for this GeoKret';
+END IF;
+
+RETURN NEW;
+END;
+$BODY$;
+EOL
+        );
+    }
+
+    public function down(): void {
+        $this->execute(<<<'EOL'
+CREATE OR REPLACE FUNCTION geokrety.moves_moved_on_datetime_checker()
+    RETURNS trigger
+    LANGUAGE 'plpgsql'
+    VOLATILE
+    COST 100
+AS $BODY$
+DECLARE
+_geokret gk_geokrety;
+BEGIN
+
+SELECT *
+FROM gk_geokrety
+WHERE id = NEW.geokret
+INTO _geokret;
+
+-- move before GK birth
+IF DATE_TRUNC('MINUTE', NEW.moved_on_datetime) < DATE_TRUNC('MINUTE', _geokret.born_on_datetime) THEN
+	RAISE 'Move date (%) time can not be before GeoKret birth (%)', DATE_TRUNC('MINUTE', NEW.moved_on_datetime), DATE_TRUNC('MINUTE', _geokret.born_on_datetime);
+-- move after NOW()
+ELSIF NEW.moved_on_datetime > NOW()::timestamp(0) THEN
+	RAISE 'The date is in the future (if you are an inventor of a time travelling machine, contact us please!)';
+-- same move on this GK at this datetime
+ELSIF COUNT(*) > 0 FROM gk_moves WHERE moved_on_datetime = NEW.moved_on_datetime AND "geokret" = NEW.geokret AND id != NEW.id AND move_type NOT IN (2::smallint) AND NEW.move_type NOT IN (2::smallint) THEN
+	RAISE 'A move at the exact same date already exists for this GeoKret';
+END IF;
+
+RETURN NEW;
+END;
+$BODY$;
+EOL
+        );
+    }
+}

--- a/website/db/tests/test-30-moves-moved-on-datetime.sql
+++ b/website/db/tests/test-30-moves-moved-on-datetime.sql
@@ -3,7 +3,7 @@
 BEGIN;
 
 -- SELECT * FROM no_plan();
-SELECT plan(23);
+SELECT plan(29);
 
 \set nice '\'0101000020E6100000F6285C8FC2F51C405C8FC2F528DC4540\''
 \set move_type_comment 2
@@ -70,6 +70,17 @@ SELECT lives_ok($$INSERT INTO "gk_moves" ("id", "geokret", "author", "moved_on_d
 SELECT lives_ok($$INSERT INTO "gk_moves" ("id", "geokret", "author", "moved_on_datetime", "move_type") VALUES (15, 13, 1, '2020-04-08 00:00:00+00', 1)$$);
 SELECT throws_ok($$INSERT INTO "gk_moves" ("id", "geokret", "author", "moved_on_datetime", "move_type") VALUES (16, 13, 1, '2020-04-08 00:00:00+00', 1)$$);
 SELECT lives_ok($$INSERT INTO "gk_moves" ("id", "geokret", "author", "moved_on_datetime", "move_type") VALUES (17, 13, 1, '2020-04-08 00:00:00+00', 2)$$);
+
+-- Multiple "met" can exists at this datetime - only if GK isn't collectible
+INSERT INTO "gk_geokrety" ("id", "name", "type", "created_on_datetime") VALUES (14, 'test', 0, '2025-04-02 13:02:00+00');
+SELECT lives_ok($$INSERT INTO "gk_moves" ("id", "geokret", "author", "moved_on_datetime", "move_type") VALUES (22, 14, 1, '2025-04-02 13:03:00+00', 1)$$);
+SELECT throws_ok($$INSERT INTO "gk_moves" ("id", "geokret", "author", "moved_on_datetime", "move_type") VALUES (23, 14, 1, '2025-04-02 13:03:00+00', 3)$$); -- GK is collectible
+SELECT lives_ok($$INSERT INTO "gk_moves" ("id", "geokret", "author", "moved_on_datetime", "move_type") VALUES (24, 14, 1, '2025-04-02 13:03:00+00', 2)$$);
+SELECT lives_ok($$UPDATE gk_geokrety SET non_collectible=NOW() WHERE id = 14::bigint$$);
+SELECT lives_ok($$INSERT INTO "gk_moves" ("id", "geokret", "author", "moved_on_datetime", "move_type") VALUES (25, 14, 1, '2025-04-02 13:03:00+00', 3)$$);
+SELECT lives_ok($$INSERT INTO "gk_moves" ("id", "geokret", "author", "moved_on_datetime", "move_type") VALUES (26, 14, 1, '2025-04-02 13:03:00+00', 3)$$);
+
+
 
 -- Finish the tests and clean up.
 SELECT * FROM finish();


### PR DESCRIPTION
If the GK is marked as "non-collectible" then we allow to use the same datetime as another move. Useful for the use case from samuel: Just imagine one GK present at a geocaching.com mega-event, on a car for example. You will have thousands of people wanting to log it in a few hours.

If the GK is not marked as non-collectible, the "met" move type will virtually change the GK position, in this case, the move date should be strict.

Should fix the issue on gk side for cgeo/cgeo#5182