### PR TITLE
feat: add hidden comment support

### DIFF
--- a/website/app-templates/smarty/elements/move.tpl
+++ b/website/app-templates/smarty/elements/move.tpl
@@ -1,6 +1,6 @@
 <a class="anchor" id="log{$move->id}"></a>
 <div class="panel panel-default{if $move->isAuthor()} enable-dropzone dropzone{/if}" id="move-{$move->id}" data-gk-type="move" data-id="{$move->id}">
-    <div class="panel-body{if $move->isAuthor()} dropzone{/if}">
+    <div class="panel-body{if $move->isAuthor()} dropzone{/if}{if $move->comment_hidden} border-move-comment-hidden{/if}">
 
         <div class="row">
             <div class="col-xs-2 move-type">
@@ -30,7 +30,7 @@
 
                 <div class="row">
                     <div class="col-xs-12 move-comment">
-                        {$move->comment|markdown nofilter}
+                        {$move|movemsg nofilter}
                     </div>
                 </div>
 

--- a/website/app-templates/smarty/elements/move_as_list.tpl
+++ b/website/app-templates/smarty/elements/move_as_list.tpl
@@ -12,7 +12,7 @@
         {if !is_null($move->lat) and !is_null($move->lon)}{$move->country|country nofilter}{/if}
         {$move|cachelink nofilter}
     </td>
-    <td><span title="{$move->comment|markdown:'text'}">{$move->comment|markdown:'text'|truncate:80:"(…)" nofilter}</span></td>
+    <td><span title="{$move->comment|markdown:'text'}">{$move|movemsg:'text':80 nofilter}</span></td>
     <td class="text-center" nowrap>
         {$move->moved_on_datetime|print_date nofilter}
         <br />

--- a/website/app-templates/smarty/elements/move_as_list_search_by_waypoint.tpl
+++ b/website/app-templates/smarty/elements/move_as_list_search_by_waypoint.tpl
@@ -8,7 +8,7 @@
         {$move->country|country nofilter}
         {$move|cachelink nofilter}
     </td>
-    <td><span title="{$move->comment|markdown:'text'}">{$move->comment|markdown:'text'|truncate:60:"(…)" nofilter}</span></td>
+    <td><span title="{$move->comment|markdown:'text'}">{$move|movemsg:'text':60 nofilter}</span></td>
     <td class="text-center" nowrap>
         {$move->moved_on_datetime|print_date nofilter}
         <br />

--- a/website/app-templates/smarty/extension/SmartyGeokretyExtension.php
+++ b/website/app-templates/smarty/extension/SmartyGeokretyExtension.php
@@ -133,6 +133,8 @@ class SmartyGeokretyExtension extends Smarty\Extension\Base {
                 return [$this, 'smarty_modifier_medal'];
             case 'movelink':
                 return [$this, 'smarty_modifier_movelink'];
+            case 'movemsg':
+                return [$this, 'smarty_modifier_movemsg'];
             case 'newslink':
                 return [$this, 'smarty_modifier_newslink'];
             case 'picture':
@@ -572,6 +574,35 @@ EOT;
             $target_html,
             self::smarty_modifier_escape($text),
         );
+    }
+
+    /**
+     * Purpose:  outputs a move link.
+     */
+    public function smarty_modifier_movemsg(GeoKrety\Model\Move $move, ?string $mode = 'html', ?int $truncate = null): string {
+        if (!is_null($truncate) && is_numeric($truncate)) {
+            $move->comment = mb_strimwidth($move->comment, 0, $truncate, '(…)');
+        }
+        $html = $this->smarty_modifier_markdown($move->comment, $mode);
+        if (!$move->isCommentHidden() or empty($move->comment)) {
+            return $html;
+        }
+        $data = [];
+        $data[] = sprintf(
+            _('<i class="text-muted move-comment-hidden" data-comment-id="%s" data-type="reveal-comment">%s %s</i>'),
+            $move->id,
+            _('This comment may contain spoilers and is hidden.'),
+            _('Click to toggle visibility.')
+        );
+        // Its safe to use rot13 here as it's not sensible data just a opt-in display.
+        $data[] = '<div class="comment-hidden">';
+        $data[] = str_rot13($this->smarty_modifier_markdown($move->comment, 'text'));
+        $data[] = '</div>';
+        $data[] = '<div class="comment-hidden hidden">';
+        $data[] = $html;
+        $data[] = '</div>';
+
+        return implode('', $data);
     }
 
     /**

--- a/website/app-templates/smarty/forms/geokret.tpl
+++ b/website/app-templates/smarty/forms/geokret.tpl
@@ -74,6 +74,21 @@
                 </p>
                 </div>
             </div>
+
+            <div class="form-group">
+                <label for="checkboxCommentsHidden" class="col-sm-2 control-label">{t}Hide comments{/t}</label>
+                <div class="col-sm-10">
+                  <div class="checkbox">
+                    <label>
+                        <input type="checkbox" id="checkboxCommentsHidden" name="comments_hidden" {if $geokret->areCommentsHidden()}checked{/if} aria-describedby="helpCheckboxCommentsHidden">
+                    </label>
+                  </div>
+                <p id="helpCheckboxCommentsHidden" class="help-block">
+                    {t}All move comments will be hidden by default.{/t}
+                    {t}Users will not see them unless they choose to.{/t}
+                </p>
+                </div>
+            </div>
         {/if}
 
             <div class="form-group">

--- a/website/app-templates/smarty/forms/move.tpl
+++ b/website/app-templates/smarty/forms/move.tpl
@@ -292,6 +292,19 @@
                         </div>
                     </div>
 
+                    <div class="form-group">
+                        <div class="col-sm-offset-2 col-sm-6">
+                            <label for="checkboxCommentHidden" class="col-sm-2 control-label"></label>
+
+                            <div class="checkbox">
+                                <label>
+                                    <input type="checkbox" name="comment_hidden" id="checkboxCommentHidden" {if $move->comment_hidden}checked{/if} />
+                                    {t}Hide comment{/t}
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+
                 </div>
             </div>
         </div>

--- a/website/app-templates/smarty/javascripts.tpl
+++ b/website/app-templates/smarty/javascripts.tpl
@@ -35,6 +35,7 @@
 {include file='js/lightbox2.tpl.js'}
 {include file='js/dialogs/dialog_login.tpl.js'}{*load js/dialogs/dialog_login all the time as it may be necessary when user leave it's session open too long*}
 {include file='js/search_advanced.tpl.js'}
+{include file='js/comments_hidden.tpl.js'}
 
 {block name=javascript_modal}{/block}
 {block name=javascript}{/block}

--- a/website/app-templates/smarty/js/comments_hidden.tpl.js
+++ b/website/app-templates/smarty/js/comments_hidden.tpl.js
@@ -1,0 +1,4 @@
+$(document).on("click", "i.move-comment-hidden", function() {
+    $(this).parent().find("div.comment-hidden").toggleClass("hidden");
+    $(this).toggleClass("hidden");
+});

--- a/website/app-templates/smarty/pages/help_api.tpl
+++ b/website/app-templates/smarty/pages/help_api.tpl
@@ -394,6 +394,9 @@ var_dump($gk);
             <dt><code>comment</code></dt>
             <dd>(<i>optional</i>) comment to the log (ex: <code>It is a good place for this GeoKret!</code>)</dd>
 
+            <dt><code>comment_hidden</code></dt>
+            <dd>(<i>optional</i>) whether the comment is hidden (ex: <code>true</code> or <code>false</code>, default: <code>false</code>)</dd>
+
             <dt><code>app</code></dt>
             <dd>(<i>optional</i>) application name, <=16 chars (ex: <code>c:geo</code>)</dd>
 

--- a/website/app/GeoKrety/Controller/Pages/GeokretEdit.php
+++ b/website/app/GeoKrety/Controller/Pages/GeokretEdit.php
@@ -28,6 +28,7 @@ class GeokretEdit extends GeokretFormBase {
         $geokret->copyFrom('POST', ['name', 'born_on_datetime', 'type', 'mission', 'label_template', 'label_languages']);
         $this->manageCollectible($f3, $geokret);
         $this->manageParked($f3, $geokret);
+        $this->manageCommentsHidden($f3, $geokret);
         $this->loadSelectedTemplate($f3);
 
         if ($geokret->validate()) {
@@ -72,5 +73,9 @@ class GeokretEdit extends GeokretFormBase {
         if (!is_null($geokret->parked)) {
             $geokret->parked = null;
         }
+    }
+
+    private function manageCommentsHidden($f3, \GeoKrety\Model\Geokret $geokret): void {
+        $geokret->comments_hidden = filter_var($f3->get('POST.comments_hidden'), FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/website/app/GeoKrety/Model/Geokret.php
+++ b/website/app/GeoKrety/Model/Geokret.php
@@ -34,6 +34,7 @@ use GeoKrety\LogType;
  * @property bool missing
  * @property int|GeokretyType type
  * @property int|Label label_template
+ * @property bool comments_hidden
  */
 class Geokret extends Base {
     use \Validation\Traits\CortexTrait;
@@ -159,6 +160,10 @@ class Geokret extends Base {
             'type' => Schema::DT_DATETIME,
             'nullable' => true,
             'validate' => 'is_date',
+        ],
+        'comments_hidden' => [
+            'type' => Schema::DT_BOOLEAN,
+            'default' => false,
         ],
     ];
 
@@ -336,6 +341,10 @@ class Geokret extends Base {
         return !is_null($this->parked);
     }
 
+    public function areCommentsHidden(): bool {
+        return $this->comments_hidden;
+    }
+
     public function countryTrack(): array {
         $sql = <<<'SQL'
 SELECT geokret,
@@ -379,6 +388,7 @@ SQL;
             'gkid' => $this->gkid,
             'collectible' => $this->isCollectible(),
             'parked' => $this->isParked(),
+            'comments_hidden' => $this->comments_hidden,
             // 'tracking_code' => $this->tracking_code,
             // 'name' => $this->name,
             // 'mission' => $this->mission,

--- a/website/app/GeoKrety/Service/Moves.php
+++ b/website/app/GeoKrety/Service/Moves.php
@@ -20,6 +20,7 @@ class Moves {
             'app' => $f3->get('POST.app'),
             'app_ver' => $f3->get('POST.app_ver'),
             'comment' => $f3->get('POST.comment'),
+            'comment_hidden' => $f3->exists('POST.comment_hidden') ? filter_var($f3->get('POST.comment_hidden'), FILTER_VALIDATE_BOOLEAN) : false,
             'coordinates' => $f3->get('POST.coordinates'),
             'date' => $f3->get('POST.date'),
             'hour' => $f3->get('POST.hour'),
@@ -46,6 +47,7 @@ class Moves {
             $move->username = $move_data['username'];
         }
         $move->comment = $move_data['comment'];
+        $move->comment_hidden = $move_data['comment_hidden'];
         $move->app = $move_data['app'];
         $move->app_ver = $move_data['app_ver'];
 

--- a/website/app/GeoKrety/Service/Xml/GeokretyExport.php
+++ b/website/app/GeoKrety/Service/Xml/GeokretyExport.php
@@ -82,6 +82,7 @@ class GeokretyExport extends GeokretyBaseExport {
 
         $xml->startElement('moves');
         $xml->writeAttribute('id', $move->id);
+        $xml->writeAttribute('hidden', $move->comment_hidden ? 'true' : 'false');
 
         $xml->startElement('geokret');
         // Not following relation prevent a memory leak bug
@@ -126,11 +127,11 @@ class GeokretyExport extends GeokretyBaseExport {
 
         $xml->startElement('comment_html');
         $xml->writeCdata(Markdown::toHtml($move->comment));
-        $xml->endElement(); // comment
+        $xml->endElement(); // comment_html
 
         $xml->startElement('comment_markdown');
         $xml->writeCdata($move->comment);
-        $xml->endElement(); // comment
+        $xml->endElement(); // comment_markdown
 
         $xml->startElement('logtype');
         $xml->writeAttribute('id', $move->move_type->getLogTypeId());

--- a/website/app/GeoKrety/Service/Xml/GeokretyExport2Details.php
+++ b/website/app/GeoKrety/Service/Xml/GeokretyExport2Details.php
@@ -116,6 +116,7 @@ class GeokretyExport2Details extends GeokretyExport2 {
         $xml->writeAttribute('only_last', GK_API_EXPORT_GEOKRET_DETAILS_MOVES_LIMIT);
         foreach ($geokret->moves ?: [] as $move) {
             $xml->startElement('move');
+            $xml->writeAttribute('hidden', $move->comment_hidden ? 'true' : 'false');
 
             $xml->startElement('id');
             $xml->writeCdata($move->id);

--- a/website/db/migrations/20260117111253_comments_hidden.php
+++ b/website/db/migrations/20260117111253_comments_hidden.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CommentsHidden extends AbstractMigration {
+    public function up(): void {
+        $table_geokrety = $this->table('geokrety.gk_geokrety');
+        $table_geokrety->addColumn('comments_hidden', 'boolean', [
+            'default' => false,
+            'null' => false,
+            'after' => 'description',
+        ])
+            ->update();
+        $table_moves = $this->table('geokrety.gk_moves');
+        $table_moves->addColumn('comment_hidden', 'boolean', [
+            'default' => false,
+            'null' => false,
+            'after' => 'comment',
+        ])
+            ->update();
+        $table_users_settings_parameters = $this->table('geokrety.gk_users_settings_parameters');
+        $table_users_settings_parameters->insert([
+            [
+                'name' => 'HIDDEN_COMMENTS_REVEAL_ALL',
+                'type' => 'bool',
+                'default' => 'false',
+                'description' => 'Show every comment that was marked hidden',
+            ],
+            [
+                'name' => 'HIDDEN_COMMENTS_REVEAL_OWNED_GEOKRETY',
+                'type' => 'bool',
+                'default' => 'true',
+                'description' => 'Show hidden comments only for GeoKrety you own',
+            ],
+        ])->saveData();
+    }
+
+    public function down(): void {
+        $this->table('geokrety.gk_geokrety')
+            ->removeColumn('comments_hidden')
+            ->update();
+        $this->table('geokrety.gk_moves')
+            ->removeColumn('comment_hidden')
+            ->update();
+        $this->execute(<<<EOL
+            DELETE FROM geokrety.gk_users_settings_parameters
+            WHERE name IN ('HIDDEN_COMMENTS_REVEAL_ALL', 'HIDDEN_COMMENTS_REVEAL_OWNED_GEOKRETY');
+EOL);
+    }
+}

--- a/website/public/app-ui/css/geokret-details.scss
+++ b/website/public/app-ui/css/geokret-details.scss
@@ -43,3 +43,7 @@
     }
   }
 }
+
+.border-move-comment-hidden {
+    border: 2px dashed lightgray !important;
+}


### PR DESCRIPTION
Closes #1344

This adds:
- a checkbox on the move page to hide the comment
- a checkbox on the GeoKret edit page to hide all comments
- Custom user settings to reveal all comments on the site
- Custom user setting to hide hidden comments even on my GeoKrety
- A message is displayed to toggle and reveal the real message

<img width="717" height="206" alt="image" src="https://github.com/user-attachments/assets/384cadc1-90ce-41d7-af19-ce0eba05eef2" />
<img width="712" height="216" alt="image" src="https://github.com/user-attachments/assets/f982d2fb-95a6-4e94-9f57-3e42ed692a97" />

<img width="1156" height="852" alt="image" src="https://github.com/user-attachments/assets/0989d759-e432-474e-b1dc-72fd1df56686" />

<img width="1182" height="903" alt="image" src="https://github.com/user-attachments/assets/0827438b-f58b-49b5-a4f5-de3b213dd5ec" />

<img width="1184" height="290" alt="image" src="https://github.com/user-attachments/assets/dc74a004-3d20-4f22-8dd5-69c72b7333a2" />
